### PR TITLE
feat: issue, project, member, and label commands

### DIFF
--- a/src/huly_cli/client.py
+++ b/src/huly_cli/client.py
@@ -70,9 +70,16 @@ class HulyClient:
 
     # ── Collaborator RPC ──────────────────────────────────────────────────────
 
-    async def get_description(self, issue_id: str, blob_ref: str) -> str | None:
-        """Fetch issue description ProseMirror JSON via Collaborator RPC."""
-        doc_id = self._build_doc_id(issue_id)
+    async def get_content(
+        self, class_id: str, object_id: str, field: str, blob_ref: str
+    ) -> str | None:
+        """Fetch entity content ProseMirror JSON via Collaborator RPC.
+
+        Works for any entity class and field, e.g.:
+          - class_id="tracker:class:Issue", field="description"
+          - class_id="document:class:Document", field="content"
+        """
+        doc_id = self._build_doc_id(class_id, object_id, field)
         url = f"{self._config.url}/_collaborator/rpc/{doc_id}"
         try:
             async with httpx.AsyncClient(timeout=15.0) as http:
@@ -88,7 +95,7 @@ class HulyClient:
                     print_warning(f"getContent returned HTTP {resp.status_code}: {resp.text[:200]}")
                     return None
                 data = resp.json()
-                content = data.get("content", {}).get("description")
+                content = data.get("content", {}).get(field)
                 if content is None:
                     return None
                 if isinstance(content, (dict, list)):
@@ -98,9 +105,14 @@ class HulyClient:
             print_warning(f"getContent error: {e}")
             return None
 
-    async def set_description(self, issue_id: str, blob_ref: str, markup_json: str) -> bool:
-        """Update issue description via Collaborator RPC."""
-        doc_id = self._build_doc_id(issue_id)
+    async def set_content(
+        self, class_id: str, object_id: str, field: str, blob_ref: str, markup_json: str
+    ) -> bool:
+        """Update entity content via Collaborator RPC.
+
+        Works for any entity class and field.
+        """
+        doc_id = self._build_doc_id(class_id, object_id, field)
         url = f"{self._config.url}/_collaborator/rpc/{doc_id}"
         try:
             async with httpx.AsyncClient(timeout=15.0) as http:
@@ -114,7 +126,7 @@ class HulyClient:
                         "method": "updateContent",
                         "payload": {
                             "source": blob_ref,
-                            "content": {"description": json_mod.loads(markup_json)},
+                            "content": {field: json_mod.loads(markup_json)},
                         },
                     },
                 )
@@ -128,9 +140,25 @@ class HulyClient:
             print_warning(f"updateContent error: {e}")
             return False
 
-    def _build_doc_id(self, issue_id: str) -> str:
-        """URL-encode the collaborator document ID for an issue description."""
-        raw = f"{self._auth.workspace_uuid}|tracker:class:Issue|{issue_id}|description"
+    async def get_description(self, issue_id: str, blob_ref: str) -> str | None:
+        """Fetch issue description ProseMirror JSON via Collaborator RPC.
+
+        Thin wrapper around get_content for tracker:class:Issue / description.
+        """
+        return await self.get_content("tracker:class:Issue", issue_id, "description", blob_ref)
+
+    async def set_description(self, issue_id: str, blob_ref: str, markup_json: str) -> bool:
+        """Update issue description via Collaborator RPC.
+
+        Thin wrapper around set_content for tracker:class:Issue / description.
+        """
+        return await self.set_content(
+            "tracker:class:Issue", issue_id, "description", blob_ref, markup_json
+        )
+
+    def _build_doc_id(self, class_id: str, object_id: str, field: str) -> str:
+        """URL-encode the collaborator document ID for any entity class and field."""
+        raw = f"{self._auth.workspace_uuid}|{class_id}|{object_id}|{field}"
         return urllib.parse.quote(raw, safe="")
 
     # ── Response handling ─────────────────────────────────────────────────────

--- a/src/huly_cli/commands/components.py
+++ b/src/huly_cli/commands/components.py
@@ -1,0 +1,322 @@
+"""Components commands: list, get, create, update."""
+
+from __future__ import annotations
+
+import asyncio
+import secrets
+import time
+from typing import Annotated, Any
+
+import typer
+
+from huly_cli.auth import ensure_auth
+from huly_cli.client import HulyClient
+from huly_cli.config import load_config
+from huly_cli.errors import AuthError, HulyError, NotFoundError
+from huly_cli.models import Component
+from huly_cli.output import print_error, print_item, print_list, print_success, print_warning
+
+app = typer.Typer(help="Manage Huly components.", no_args_is_help=True)
+
+
+# ── Shared helpers ────────────────────────────────────────────────────────────
+
+
+async def _resolve_project_by_identifier(client: HulyClient, identifier: str) -> tuple[str, str]:
+    """Return (project_id, project_name) for the given identifier."""
+    projects = await client.find_all(
+        "tracker:class:Project",
+        query={"identifier": identifier.upper()},
+        options={"limit": 1},
+    )
+    if not projects:
+        raise NotFoundError(f"Project '{identifier}' not found.")
+    proj = projects[0]
+    return proj["_id"], proj.get("name", identifier)
+
+
+async def _fetch_person_map(client: HulyClient) -> dict[str, str]:
+    """Return map of person_id → display_name."""
+    raw = await client.find_all("contact:class:Person", options={"limit": 500})
+    result: dict[str, str] = {}
+    for p in raw:
+        name: str = p.get("name", "")
+        parts = name.split(",", 1)
+        display = f"{parts[1].strip()} {parts[0].strip()}" if len(parts) == 2 else name
+        result[p["_id"]] = display
+    return result
+
+
+async def _resolve_person_by_name(client: HulyClient, name: str) -> str:
+    """Fuzzy-match a person by name and return their ID."""
+    persons = await client.find_all("contact:class:Person", options={"limit": 500})
+    query_lower = name.lower()
+    for p in persons:
+        raw_name: str = p.get("name", "")
+        parts = raw_name.split(",", 1)
+        display = f"{parts[1].strip()} {parts[0].strip()}" if len(parts) == 2 else raw_name
+        if query_lower in display.lower() or query_lower in raw_name.lower():
+            return p["_id"]
+    raise NotFoundError(f"Person '{name}' not found.")
+
+
+def _truncate(text: str, max_len: int = 60) -> str:
+    return text if len(text) <= max_len else text[: max_len - 3] + "..."
+
+
+def _component_to_row(comp: Component, person_map: dict[str, str]) -> dict[str, Any]:
+    lead_name = person_map.get(comp.lead, comp.lead) if comp.lead else ""
+    return {
+        "label": comp.label,
+        "description": _truncate(comp.description),
+        "lead": lead_name,
+        "id": comp.id,
+    }
+
+
+def _component_to_detail(comp: Component, person_map: dict[str, str]) -> dict[str, Any]:
+    lead_name = person_map.get(comp.lead, comp.lead) if comp.lead else ""
+    return {
+        "label": comp.label,
+        "id": comp.id,
+        "space": comp.space,
+        "description": comp.description,
+        "lead": lead_name,
+        "lead_id": comp.lead,
+        "created_by": comp.created_by,
+        "modified_by": comp.modified_by,
+    }
+
+
+# ── Commands ──────────────────────────────────────────────────────────────────
+
+
+@app.command("list")
+def components_list(
+    ctx: typer.Context,
+    project: Annotated[
+        str | None,
+        typer.Option("--project", "-p", help="Filter by project identifier (e.g. ROA)."),
+    ] = None,
+    limit: Annotated[
+        int,
+        typer.Option("--limit", "-n", help="Maximum number of components to return."),
+    ] = 50,
+) -> None:
+    """List components, with optional project filter."""
+    overrides: dict = ctx.obj or {}
+    config = load_config(
+        url_override=overrides.get("url"),
+        workspace_override=overrides.get("workspace"),
+    )
+
+    async def _run() -> list[dict[str, Any]]:
+        auth = await ensure_auth(config)
+        async with HulyClient(config, auth) as client:
+            query: dict[str, Any] = {}
+            if project:
+                project_id, _ = await _resolve_project_by_identifier(client, project)
+                query["space"] = project_id
+
+            raw = await client.find_all(
+                "tracker:class:Component",
+                query=query,
+                options={"limit": limit},
+            )
+            components = [Component.model_validate(doc) for doc in raw]
+            person_map = await _fetch_person_map(client)
+
+        return [_component_to_row(c, person_map) for c in components]
+
+    try:
+        rows = asyncio.run(_run())
+    except AuthError as e:
+        print_error(e.message, hint="Run 'huly auth login' to authenticate.")
+        raise typer.Exit(2) from e
+    except HulyError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+
+    print_list(rows, columns=["label", "description", "lead", "id"], title="Components")
+
+
+@app.command("get")
+def components_get(
+    ctx: typer.Context,
+    component_id: str = typer.Argument(..., help="Component internal ID."),
+) -> None:
+    """Get details of a component."""
+    overrides: dict = ctx.obj or {}
+    config = load_config(
+        url_override=overrides.get("url"),
+        workspace_override=overrides.get("workspace"),
+    )
+
+    async def _run() -> dict[str, Any]:
+        auth = await ensure_auth(config)
+        async with HulyClient(config, auth) as client:
+            raw = await client.find_all(
+                "tracker:class:Component",
+                query={"_id": component_id},
+                options={"limit": 1},
+            )
+            if not raw:
+                raise NotFoundError(f"Component '{component_id}' not found.")
+            comp = Component.model_validate(raw[0])
+            person_map = await _fetch_person_map(client)
+        return _component_to_detail(comp, person_map)
+
+    try:
+        data = asyncio.run(_run())
+    except NotFoundError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+    except AuthError as e:
+        print_error(e.message, hint="Run 'huly auth login' to authenticate.")
+        raise typer.Exit(2) from e
+    except HulyError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+
+    print_item(data, title=f"Component: {data.get('label', component_id)}")
+
+
+@app.command("create")
+def components_create(
+    ctx: typer.Context,
+    label: Annotated[str, typer.Option("--label", help="Component label.")] = ...,
+    project: Annotated[
+        str, typer.Option("--project", help='Project identifier (e.g. "ROA").')
+    ] = ...,
+    lead: Annotated[
+        str | None, typer.Option("--lead", help="Lead person name (fuzzy match).")
+    ] = None,
+    description: Annotated[
+        str | None, typer.Option("--description", help="Component description.")
+    ] = None,
+) -> None:
+    """Create a new component."""
+    overrides: dict = ctx.obj or {}
+    config = load_config(
+        url_override=overrides.get("url"),
+        workspace_override=overrides.get("workspace"),
+    )
+
+    async def _run() -> str:
+        auth = await ensure_auth(config)
+        async with HulyClient(config, auth) as client:
+            project_id, _ = await _resolve_project_by_identifier(client, project)
+
+            lead_id: str | None = None
+            if lead:
+                lead_id = await _resolve_person_by_name(client, lead)
+
+            new_id = secrets.token_hex(12)
+
+            transaction = {
+                "_class": "core:class:TxCreateDoc",
+                "objectClass": "tracker:class:Component",
+                "objectSpace": project_id,
+                "objectId": new_id,
+                "attributes": {
+                    "label": label,
+                    "description": description or "",
+                    "lead": lead_id,
+                },
+                "modifiedBy": auth.account_id,
+                "modifiedOn": int(time.time() * 1000),
+            }
+
+            await client.tx(transaction)
+        return new_id
+
+    try:
+        new_id = asyncio.run(_run())
+        print_success(f"Component created in project '{project}' (id: {new_id})")
+    except NotFoundError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+    except AuthError as e:
+        print_error(e.message, hint="Run 'huly auth login' to authenticate.")
+        raise typer.Exit(2) from e
+    except HulyError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+
+
+@app.command("update")
+def components_update(
+    ctx: typer.Context,
+    component_id: str = typer.Argument(..., help="Component internal ID."),
+    label: Annotated[str | None, typer.Option("--label", help="New component label.")] = None,
+    lead: Annotated[
+        str | None, typer.Option("--lead", help='New lead person name. Use "" to unassign.')
+    ] = None,
+    description: Annotated[
+        str | None, typer.Option("--description", help="New description.")
+    ] = None,
+) -> None:
+    """Update an existing component."""
+    overrides: dict = ctx.obj or {}
+    config = load_config(
+        url_override=overrides.get("url"),
+        workspace_override=overrides.get("workspace"),
+    )
+
+    async def _run() -> None:
+        auth = await ensure_auth(config)
+        async with HulyClient(config, auth) as client:
+            raw = await client.find_all(
+                "tracker:class:Component",
+                query={"_id": component_id},
+                options={"limit": 1},
+            )
+            if not raw:
+                raise NotFoundError(f"Component '{component_id}' not found.")
+            comp = Component.model_validate(raw[0])
+
+            operations: dict = {}
+
+            if label is not None:
+                operations["label"] = label
+
+            if description is not None:
+                operations["description"] = description
+
+            if lead is not None:
+                if lead == "":
+                    operations["lead"] = None
+                else:
+                    lead_id = await _resolve_person_by_name(client, lead)
+                    operations["lead"] = lead_id
+
+            if not operations:
+                print_warning(
+                    "No fields to update — provide at least one of --label, --lead, --description."
+                )
+                return
+
+            transaction = {
+                "_class": "core:class:TxUpdateDoc",
+                "objectClass": "tracker:class:Component",
+                "objectSpace": comp.space,
+                "objectId": comp.id,
+                "operations": operations,
+                "modifiedBy": auth.account_id,
+                "modifiedOn": int(time.time() * 1000),
+            }
+
+            await client.tx(transaction)
+
+    try:
+        asyncio.run(_run())
+        print_success(f"Component {component_id} updated.")
+    except NotFoundError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+    except AuthError as e:
+        print_error(e.message, hint="Run 'huly auth login' to authenticate.")
+        raise typer.Exit(2) from e
+    except HulyError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e

--- a/src/huly_cli/commands/documents.py
+++ b/src/huly_cli/commands/documents.py
@@ -1,0 +1,442 @@
+"""Documents commands: list, get, create, update, describe."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import secrets
+import time
+from typing import Annotated, Any
+
+import typer
+
+from huly_cli.auth import ensure_auth
+from huly_cli.client import HulyClient
+from huly_cli.config import load_config
+from huly_cli.errors import AuthError, HulyError, NotFoundError
+from huly_cli.models import Document
+from huly_cli.output import (
+    console,
+    is_json_mode,
+    print_error,
+    print_item,
+    print_list,
+    print_success,
+    print_warning,
+)
+
+app = typer.Typer(help="Manage Huly documents.", no_args_is_help=True)
+
+
+# ── Shared helpers ────────────────────────────────────────────────────────────
+
+
+async def _fetch_teamspace_map(client: HulyClient) -> dict[str, str]:
+    """Return map of teamspace_id → name."""
+    raw = await client.find_all("document:class:Teamspace", options={"limit": 200})
+    return {ts["_id"]: ts.get("name", ts["_id"]) for ts in raw}
+
+
+async def _resolve_teamspace_by_name(client: HulyClient, name: str) -> str:
+    """Resolve a teamspace name to its ID. Raises NotFoundError if not found."""
+    raw = await client.find_all("document:class:Teamspace", options={"limit": 200})
+    name_lower = name.lower()
+    for ts in raw:
+        if ts.get("name", "").lower() == name_lower:
+            return ts["_id"]
+    raise NotFoundError(f"Teamspace '{name}' not found.")
+
+
+def _doc_to_row(doc: Document, space_map: dict[str, str]) -> dict[str, Any]:
+    space_name = space_map.get(doc.space, doc.space)
+    parent = "" if doc.parent in ("document:ids:NoParent", "") else doc.parent
+    return {
+        "title": doc.title,
+        "space": space_name,
+        "parent": parent,
+        "id": doc.id,
+    }
+
+
+def _doc_to_detail(doc: Document, space_map: dict[str, str]) -> dict[str, Any]:
+    space_name = space_map.get(doc.space, doc.space)
+    parent = "" if doc.parent in ("document:ids:NoParent", "") else doc.parent
+    return {
+        "title": doc.title,
+        "id": doc.id,
+        "space": space_name,
+        "space_id": doc.space,
+        "parent": parent,
+        "content_ref": doc.content,
+        "attachments": doc.attachments,
+        "labels": doc.labels,
+        "comments": doc.comments,
+        "rank": doc.rank,
+        "created_by": doc.created_by,
+        "created_on": doc.created_on,
+        "modified_by": doc.modified_by,
+        "modified_on": doc.modified_on,
+    }
+
+
+# ── Commands ──────────────────────────────────────────────────────────────────
+
+
+@app.command("list")
+def docs_list(
+    ctx: typer.Context,
+    space: Annotated[
+        str | None,
+        typer.Option("--space", "-s", help="Filter by teamspace name."),
+    ] = None,
+    limit: Annotated[
+        int,
+        typer.Option("--limit", "-n", help="Maximum number of documents to return."),
+    ] = 50,
+) -> None:
+    """List documents, with optional teamspace filter."""
+    overrides: dict = ctx.obj or {}
+    config = load_config(
+        url_override=overrides.get("url"),
+        workspace_override=overrides.get("workspace"),
+    )
+
+    async def _run() -> list[dict[str, Any]]:
+        auth = await ensure_auth(config)
+        async with HulyClient(config, auth) as client:
+            space_map = await _fetch_teamspace_map(client)
+
+            query: dict[str, Any] = {}
+            if space:
+                space_id = await _resolve_teamspace_by_name(client, space)
+                query["space"] = space_id
+
+            raw = await client.find_all(
+                "document:class:Document",
+                query=query,
+                options={"limit": limit},
+            )
+            docs = [Document.model_validate(doc) for doc in raw]
+
+        return [_doc_to_row(d, space_map) for d in docs]
+
+    try:
+        rows = asyncio.run(_run())
+    except AuthError as e:
+        print_error(e.message, hint="Run 'huly auth login' to authenticate.")
+        raise typer.Exit(2) from e
+    except HulyError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+
+    print_list(rows, columns=["title", "space", "parent", "id"], title="Documents")
+
+
+@app.command("get")
+def docs_get(
+    ctx: typer.Context,
+    doc_id: str = typer.Argument(..., help="Document internal ID."),
+) -> None:
+    """Get details of a document."""
+    overrides: dict = ctx.obj or {}
+    config = load_config(
+        url_override=overrides.get("url"),
+        workspace_override=overrides.get("workspace"),
+    )
+
+    async def _run() -> dict[str, Any]:
+        auth = await ensure_auth(config)
+        async with HulyClient(config, auth) as client:
+            raw = await client.find_all(
+                "document:class:Document",
+                query={"_id": doc_id},
+                options={"limit": 1},
+            )
+            if not raw:
+                raise NotFoundError(f"Document '{doc_id}' not found.")
+            doc = Document.model_validate(raw[0])
+            space_map = await _fetch_teamspace_map(client)
+        return _doc_to_detail(doc, space_map)
+
+    try:
+        data = asyncio.run(_run())
+    except NotFoundError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+    except AuthError as e:
+        print_error(e.message, hint="Run 'huly auth login' to authenticate.")
+        raise typer.Exit(2) from e
+    except HulyError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+
+    print_item(data, title=f"Document: {data.get('title', doc_id)}")
+
+
+@app.command("create")
+def docs_create(
+    ctx: typer.Context,
+    title: Annotated[str, typer.Option("--title", help="Document title.")] = ...,
+    space: Annotated[str, typer.Option("--space", help="Teamspace name.")] = ...,
+    parent: Annotated[str | None, typer.Option("--parent", help="Parent document ID.")] = None,
+) -> None:
+    """Create a new document."""
+    overrides: dict = ctx.obj or {}
+    config = load_config(
+        url_override=overrides.get("url"),
+        workspace_override=overrides.get("workspace"),
+    )
+
+    async def _run() -> str:
+        auth = await ensure_auth(config)
+        async with HulyClient(config, auth) as client:
+            space_id = await _resolve_teamspace_by_name(client, space)
+
+            parent_id = parent if parent else "document:ids:NoParent"
+            new_id = secrets.token_hex(12)
+
+            transaction = {
+                "_class": "core:class:TxCreateDoc",
+                "objectClass": "document:class:Document",
+                "objectSpace": space_id,
+                "objectId": new_id,
+                "attributes": {
+                    "title": title,
+                    "content": "",
+                    "parent": parent_id,
+                    "attachments": 0,
+                    "embeddings": 0,
+                    "labels": 0,
+                    "comments": 0,
+                    "references": 0,
+                    "rank": "",
+                },
+                "modifiedBy": auth.account_id,
+                "modifiedOn": int(time.time() * 1000),
+            }
+
+            await client.tx(transaction)
+        return new_id
+
+    try:
+        new_id = asyncio.run(_run())
+        print_success(f"Document created in teamspace '{space}' (id: {new_id})")
+    except NotFoundError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+    except AuthError as e:
+        print_error(e.message, hint="Run 'huly auth login' to authenticate.")
+        raise typer.Exit(2) from e
+    except HulyError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+
+
+@app.command("update")
+def docs_update(
+    ctx: typer.Context,
+    doc_id: str = typer.Argument(..., help="Document internal ID."),
+    title: Annotated[str | None, typer.Option("--title", help="New document title.")] = None,
+) -> None:
+    """Update an existing document."""
+    overrides: dict = ctx.obj or {}
+    config = load_config(
+        url_override=overrides.get("url"),
+        workspace_override=overrides.get("workspace"),
+    )
+
+    async def _run() -> None:
+        auth = await ensure_auth(config)
+        async with HulyClient(config, auth) as client:
+            raw = await client.find_all(
+                "document:class:Document",
+                query={"_id": doc_id},
+                options={"limit": 1},
+            )
+            if not raw:
+                raise NotFoundError(f"Document '{doc_id}' not found.")
+            doc = Document.model_validate(raw[0])
+
+            operations: dict = {}
+            if title is not None:
+                operations["title"] = title
+
+            if not operations:
+                print_warning("No fields to update — provide at least one of --title.")
+                return
+
+            transaction = {
+                "_class": "core:class:TxUpdateDoc",
+                "objectClass": "document:class:Document",
+                "objectSpace": doc.space,
+                "objectId": doc.id,
+                "operations": operations,
+                "modifiedBy": auth.account_id,
+                "modifiedOn": int(time.time() * 1000),
+            }
+
+            await client.tx(transaction)
+
+    try:
+        asyncio.run(_run())
+        print_success(f"Document {doc_id} updated.")
+    except NotFoundError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+    except AuthError as e:
+        print_error(e.message, hint="Run 'huly auth login' to authenticate.")
+        raise typer.Exit(2) from e
+    except HulyError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+
+
+@app.command("describe")
+def docs_describe(
+    ctx: typer.Context,
+    doc_id: str = typer.Argument(..., help="Document internal ID."),
+    raw: Annotated[
+        bool,
+        typer.Option("--raw", help="Show raw ProseMirror JSON instead of rendered markdown."),
+    ] = False,
+    set_text: Annotated[
+        str | None,
+        typer.Option("--set", help="Set content from markdown string."),
+    ] = None,
+    set_file: Annotated[
+        str | None,
+        typer.Option("--set-file", help="Set content from a markdown file path."),
+    ] = None,
+) -> None:
+    """Read or update the content of a document.
+
+    By default, reads and displays the content. Use --set or --set-file to write.
+    """
+    if set_text and set_file:
+        print_error("Use either --set or --set-file, not both.")
+        raise typer.Exit(1)
+
+    overrides: dict = ctx.obj or {}
+    config = load_config(
+        url_override=overrides.get("url"),
+        workspace_override=overrides.get("workspace"),
+    )
+
+    # ── Write path ────────────────────────────────────────────────────────
+    if set_text is not None or set_file is not None:
+        markdown_content = set_text
+        if set_file is not None:
+            import pathlib
+
+            p = pathlib.Path(set_file)
+            if not p.exists():
+                print_error(f"File not found: {set_file}")
+                raise typer.Exit(1)
+            markdown_content = p.read_text(encoding="utf-8")
+
+        async def _write() -> str:
+            from huly_cli.markup import markdown_to_prosemirror
+
+            auth = await ensure_auth(config)
+            async with HulyClient(config, auth) as client:
+                raw_docs = await client.find_all(
+                    "document:class:Document",
+                    query={"_id": doc_id},
+                    options={"limit": 1},
+                )
+                if not raw_docs:
+                    raise NotFoundError(f"Document '{doc_id}' not found.")
+                doc = Document.model_validate(raw_docs[0])
+                if not doc.content:
+                    raise HulyError(
+                        f"Document '{doc_id}' has no content blob ref. "
+                        "Cannot update content that was never created."
+                    )
+                markup = markdown_to_prosemirror(markdown_content or "")
+                ok = await client.set_content(
+                    "document:class:Document", doc.id, "content", doc.content, markup
+                )
+                if not ok:
+                    raise HulyError("Failed to update content via Collaborator RPC.")
+            return doc.title or doc_id
+
+        try:
+            title_label = asyncio.run(_write())
+        except NotFoundError as e:
+            print_error(e.message)
+            raise typer.Exit(1) from e
+        except AuthError as e:
+            print_error(e.message, hint="Run 'huly auth login' to authenticate.")
+            raise typer.Exit(2) from e
+        except HulyError as e:
+            print_error(e.message)
+            raise typer.Exit(1) from e
+
+        print_success(f"Content updated for '{title_label}'.")
+        return
+
+    # ── Read path ─────────────────────────────────────────────────────────
+    async def _run() -> tuple[str, str | None]:
+        auth = await ensure_auth(config)
+        async with HulyClient(config, auth) as client:
+            raw_docs = await client.find_all(
+                "document:class:Document",
+                query={"_id": doc_id},
+                options={"limit": 1},
+            )
+            if not raw_docs:
+                raise NotFoundError(f"Document '{doc_id}' not found.")
+            doc = Document.model_validate(raw_docs[0])
+            if not doc.content:
+                return doc.title or doc_id, None
+            content = await client.get_content(
+                "document:class:Document", doc.id, "content", doc.content
+            )
+        return doc.title or doc_id, content
+
+    try:
+        title_label, content = asyncio.run(_run())
+    except NotFoundError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+    except AuthError as e:
+        print_error(e.message, hint="Run 'huly auth login' to authenticate.")
+        raise typer.Exit(2) from e
+    except HulyError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+
+    if content is None:
+        print_error(f"No content available for document '{title_label}'.")
+        raise typer.Exit(1)
+
+    if is_json_mode():
+        if raw:
+            print(json.dumps({"ok": True, "id": doc_id, "content_raw": content}))
+        else:
+            from huly_cli.markup import prosemirror_to_markdown
+
+            md = prosemirror_to_markdown(content)
+            print(json.dumps({"ok": True, "id": doc_id, "content": md}))
+        return
+
+    if raw:
+        try:
+            parsed = json.loads(content)
+            console.print_json(json.dumps(parsed, indent=2))
+        except (json.JSONDecodeError, TypeError):
+            console.print(content)
+    else:
+        from rich.markdown import Markdown
+        from rich.panel import Panel
+
+        from huly_cli.markup import prosemirror_to_markdown
+
+        md_text = prosemirror_to_markdown(content)
+        if md_text.strip():
+            console.print(Panel(Markdown(md_text), title=f"Content: {title_label}"))
+        else:
+            from huly_cli.markup import prosemirror_to_text
+
+            plain = prosemirror_to_text(content)
+            console.print(Panel(plain or "(empty content)", title=f"Content: {title_label}"))

--- a/src/huly_cli/commands/issues.py
+++ b/src/huly_cli/commands/issues.py
@@ -1,0 +1,617 @@
+"""Issues commands: list, get, create, update, describe."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import secrets
+import time
+from typing import Annotated, Any
+
+import typer
+
+from huly_cli.auth import ensure_auth
+from huly_cli.client import HulyClient
+from huly_cli.config import load_config
+from huly_cli.errors import AuthError, HulyError, NotFoundError
+from huly_cli.models import (
+    PRIORITY_FROM_NAME,
+    STATUS_IDS,
+    Issue,
+    Person,
+)
+from huly_cli.output import (
+    console,
+    is_json_mode,
+    print_error,
+    print_item,
+    print_list,
+    print_success,
+    print_warning,
+)
+
+app = typer.Typer(help="Manage Huly issues.", no_args_is_help=True)
+
+
+# ── Shared helpers ────────────────────────────────────────────────────────────
+
+
+async def _fetch_person_map(client: HulyClient) -> dict[str, str]:
+    """Return map of person_id → display_name."""
+    raw = await client.find_all("contact:class:Person", options={"limit": 500})
+    persons = [Person.model_validate(doc) for doc in raw]
+    return {p.id: p.display_name for p in persons}
+
+
+def _resolve_status_filter(status_name: str) -> str | None:
+    key = status_name.lower().replace(" ", "-")
+    return STATUS_IDS.get(key)
+
+
+def _issue_to_row(issue: Issue, person_map: dict[str, str]) -> dict[str, Any]:
+    assignee_name = person_map.get(issue.assignee, issue.assignee) if issue.assignee else ""
+    return {
+        "identifier": issue.identifier or issue.id,
+        "title": issue.title,
+        "status": issue.status_name,
+        "priority": issue.priority_name,
+        "assignee": assignee_name,
+    }
+
+
+def _issue_to_detail(issue: Issue, person_map: dict[str, str]) -> dict[str, Any]:
+    assignee_name = person_map.get(issue.assignee, issue.assignee) if issue.assignee else ""
+    return {
+        "identifier": issue.identifier or issue.id,
+        "title": issue.title,
+        "status": issue.status_name,
+        "priority": issue.priority_name,
+        "assignee": assignee_name,
+        "id": issue.id,
+        "space": issue.space,
+        "description_ref": issue.description,
+        "comments": issue.comments,
+        "sub_issues": issue.sub_issues,
+        "estimation": issue.estimation,
+        "due_date": issue.due_date,
+        "created_by": issue.created_by,
+        "created_on": issue.created_on,
+        "modified_by": issue.modified_by,
+        "modified_on": issue.modified_on,
+    }
+
+
+# ── Commands ──────────────────────────────────────────────────────────────────
+
+
+@app.command("list")
+def issues_list(
+    ctx: typer.Context,
+    project: Annotated[
+        str | None,
+        typer.Option("--project", "-p", help="Filter by project identifier (e.g. ROA)."),
+    ] = None,
+    status: Annotated[
+        str | None,
+        typer.Option(
+            "--status",
+            "-s",
+            help="Filter by status: backlog, todo, in-progress, done, canceled.",
+        ),
+    ] = None,
+    assignee: Annotated[
+        str | None,
+        typer.Option("--assignee", "-a", help="Filter by assignee name (fuzzy match)."),
+    ] = None,
+    limit: Annotated[
+        int,
+        typer.Option("--limit", "-n", help="Maximum number of issues to return."),
+    ] = 50,
+) -> None:
+    """List issues, with optional filters."""
+    overrides: dict = ctx.obj or {}
+    config = load_config(
+        url_override=overrides.get("url"),
+        workspace_override=overrides.get("workspace"),
+    )
+
+    async def _run() -> list[dict[str, Any]]:
+        auth = await ensure_auth(config)
+        async with HulyClient(config, auth) as client:
+            query: dict[str, Any] = {}
+            if status:
+                status_id = _resolve_status_filter(status)
+                if not status_id:
+                    valid = ", ".join(STATUS_IDS.keys())
+                    raise HulyError(f"Unknown status '{status}'. Valid values: {valid}")
+                query["status"] = status_id
+
+            raw = await client.find_all(
+                "tracker:class:Issue",
+                query=query,
+                options={"limit": limit},
+            )
+            issues = [Issue.model_validate(doc) for doc in raw]
+
+            if project:
+                prefix = project.upper() + "-"
+                issues = [i for i in issues if i.identifier.upper().startswith(prefix)]
+
+            person_map = await _fetch_person_map(client)
+
+        if assignee:
+            needle = assignee.lower()
+            issues = [
+                i for i in issues if i.assignee and needle in person_map.get(i.assignee, "").lower()
+            ]
+
+        return [_issue_to_row(i, person_map) for i in issues]
+
+    try:
+        rows = asyncio.run(_run())
+    except AuthError as e:
+        print_error(e.message, hint="Run 'huly auth login' to authenticate.")
+        raise typer.Exit(2) from e
+    except HulyError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+
+    print_list(
+        rows,
+        columns=["identifier", "title", "status", "priority", "assignee"],
+        title="Issues",
+    )
+
+
+@app.command("get")
+def issues_get(
+    ctx: typer.Context,
+    identifier: str = typer.Argument(..., help="Issue identifier (e.g. ROA-1)."),
+) -> None:
+    """Get details of an issue."""
+    overrides: dict = ctx.obj or {}
+    config = load_config(
+        url_override=overrides.get("url"),
+        workspace_override=overrides.get("workspace"),
+    )
+
+    async def _run() -> dict[str, Any]:
+        auth = await ensure_auth(config)
+        async with HulyClient(config, auth) as client:
+            raw = await client.find_all(
+                "tracker:class:Issue",
+                query={"identifier": identifier.upper()},
+                options={"limit": 1},
+            )
+            if not raw:
+                raise NotFoundError(f"Issue '{identifier}' not found.")
+            issue = Issue.model_validate(raw[0])
+            person_map = await _fetch_person_map(client)
+        return _issue_to_detail(issue, person_map)
+
+    try:
+        data = asyncio.run(_run())
+    except NotFoundError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+    except AuthError as e:
+        print_error(e.message, hint="Run 'huly auth login' to authenticate.")
+        raise typer.Exit(2) from e
+    except HulyError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+
+    print_item(data, title=f"Issue: {data.get('identifier', identifier)}")
+
+
+@app.command("create")
+def issues_create(
+    ctx: typer.Context,
+    title: Annotated[str, typer.Option("--title", help="Issue title.")] = ...,
+    project: Annotated[
+        str, typer.Option("--project", help='Project identifier (e.g. "ROA").')
+    ] = ...,
+    status: Annotated[str, typer.Option("--status", help="Status name.")] = "backlog",
+    priority: Annotated[str, typer.Option("--priority", help="Priority name or number.")] = "none",
+    assignee: Annotated[
+        str | None, typer.Option("--assignee", help="Assignee person name (fuzzy match).")
+    ] = None,
+    description: Annotated[
+        str | None, typer.Option("--description", help="Markdown description text.")
+    ] = None,
+) -> None:
+    """Create a new issue."""
+    overrides: dict = ctx.obj or {}
+    config = load_config(
+        url_override=overrides.get("url"),
+        workspace_override=overrides.get("workspace"),
+    )
+    try:
+        result = asyncio.run(
+            _create_impl(config, title, project, status, priority, assignee, description)
+        )
+        print_success(result)
+    except NotFoundError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+    except Exception as e:
+        print_error(str(e))
+        raise typer.Exit(1) from e
+
+
+async def _create_impl(
+    config,
+    title: str,
+    project: str,
+    status: str,
+    priority: str,
+    assignee: str | None,
+    description: str | None,
+) -> str:
+    auth = await ensure_auth(config)
+    async with HulyClient(config, auth) as client:
+        # Resolve project by identifier (normalise to uppercase, e.g. "roa" → "ROA")
+        projects = await client.find_all("tracker:class:Project", {"identifier": project.upper()})
+        if not projects:
+            raise NotFoundError(f"Project '{project}' not found.")
+        proj = projects[0]
+        project_id: str = proj["_id"]
+
+        # Resolve status
+        status_key = status.lower().replace(" ", "-")
+        status_id = STATUS_IDS.get(status_key)
+        if status_id is None:
+            raise NotFoundError(
+                f"Unknown status '{status}'. Valid values: {', '.join(STATUS_IDS.keys())}"
+            )
+
+        # Resolve priority
+        try:
+            priority_int = int(priority)
+        except ValueError:
+            priority_int = PRIORITY_FROM_NAME.get(priority.lower())
+            if priority_int is None:
+                raise NotFoundError(
+                    f"Unknown priority '{priority}'. Valid values: {', '.join(PRIORITY_FROM_NAME.keys())}"
+                ) from None
+
+        # Resolve assignee
+        person_id: str | None = None
+        if assignee:
+            persons = await client.find_all("contact:class:Person")
+            query_lower = assignee.lower()
+            match = None
+            for p in persons:
+                name: str = p.get("name", "")
+                # Build display name for matching: "LastName,FirstName" -> "FirstName LastName"
+                parts = name.split(",", 1)
+                display = f"{parts[1].strip()} {parts[0].strip()}" if len(parts) == 2 else name
+                if query_lower in display.lower() or query_lower in name.lower():
+                    match = p
+                    break
+            if match is None:
+                raise NotFoundError(f"Person '{assignee}' not found.")
+            person_id = match["_id"]
+
+        # Generate new issue ID
+        new_id = secrets.token_hex(12)
+
+        transaction = {
+            "_class": "core:class:TxCreateDoc",
+            "objectClass": "tracker:class:Issue",
+            "objectSpace": project_id,
+            "objectId": new_id,
+            "attributes": {
+                "title": title,
+                "description": "",
+                "status": status_id,
+                "priority": priority_int,
+                "assignee": person_id,
+                "kind": "tracker:taskTypes:Issue",
+                "component": None,
+                "milestone": None,
+                "number": 0,
+                "estimation": 0,
+                "remainingTime": 0,
+                "reportedTime": 0,
+                "reports": 0,
+                "relations": [],
+                "parents": [],
+                "childInfo": [],
+                "dueDate": None,
+                "rank": "",
+                "comments": 0,
+                "subIssues": 0,
+                "labels": 0,
+                "attachedTo": "tracker:ids:NoParent",
+                "attachedToClass": "tracker:class:Issue",
+                "collection": "subIssues",
+            },
+            "modifiedBy": auth.account_id,
+            "modifiedOn": int(time.time() * 1000),
+        }
+
+        await client.tx(transaction)
+
+        # Set description if provided (requires issue to exist first so it has a blob ref)
+        if description:
+            # Re-fetch the created issue to get its blob ref
+            created = await client.find_all(
+                "tracker:class:Issue", {"_id": new_id}, options={"limit": 1}
+            )
+            if created and created[0].get("description"):
+                from huly_cli.markup import markdown_to_prosemirror
+
+                markup = markdown_to_prosemirror(description)
+                ok = await client.set_description(new_id, created[0]["description"], markup)
+                if not ok:
+                    print_warning("Issue created but description could not be set.")
+
+        return f"Issue created in project {project} (id: {new_id})"
+
+
+@app.command("update")
+def issues_update(
+    ctx: typer.Context,
+    identifier: str = typer.Argument(..., help="Issue identifier (e.g. ROA-1)."),
+    title: Annotated[str | None, typer.Option("--title", help="New issue title.")] = None,
+    status: Annotated[str | None, typer.Option("--status", help="New status name.")] = None,
+    priority: Annotated[
+        str | None, typer.Option("--priority", help="New priority name or number.")
+    ] = None,
+    assignee: Annotated[
+        str | None,
+        typer.Option(
+            "--assignee", help='New assignee person name (fuzzy match). Use "" to unassign.'
+        ),
+    ] = None,
+) -> None:
+    """Update an existing issue."""
+    overrides: dict = ctx.obj or {}
+    config = load_config(
+        url_override=overrides.get("url"),
+        workspace_override=overrides.get("workspace"),
+    )
+    try:
+        asyncio.run(_update_impl(config, identifier, title, status, priority, assignee))
+        print_success(f"Issue {identifier} updated.")
+    except NotFoundError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+    except Exception as e:
+        print_error(str(e))
+        raise typer.Exit(1) from e
+
+
+async def _update_impl(
+    config,
+    identifier: str,
+    title: str | None,
+    status: str | None,
+    priority: str | None,
+    assignee: str | None,
+) -> None:
+    auth = await ensure_auth(config)
+    async with HulyClient(config, auth) as client:
+        # Find existing issue by identifier (normalise to uppercase, e.g. "roa-1" → "ROA-1")
+        issues = await client.find_all("tracker:class:Issue", {"identifier": identifier.upper()})
+        if not issues:
+            raise NotFoundError(f"Issue '{identifier}' not found.")
+        issue = issues[0]
+        issue_id: str = issue["_id"]
+        issue_space: str = issue.get("space", "")
+
+        operations: dict = {}
+
+        if title is not None:
+            operations["title"] = title
+
+        if status is not None:
+            status_key = status.lower().replace(" ", "-")
+            status_id = STATUS_IDS.get(status_key)
+            if status_id is None:
+                raise NotFoundError(
+                    f"Unknown status '{status}'. Valid values: {', '.join(STATUS_IDS.keys())}"
+                )
+            operations["status"] = status_id
+
+        if priority is not None:
+            try:
+                priority_int = int(priority)
+            except ValueError:
+                priority_int = PRIORITY_FROM_NAME.get(priority.lower())
+                if priority_int is None:
+                    raise NotFoundError(
+                        f"Unknown priority '{priority}'. Valid values: {', '.join(PRIORITY_FROM_NAME.keys())}"
+                    ) from None
+            operations["priority"] = priority_int
+
+        if assignee is not None:
+            if assignee == "":
+                # Unassign
+                operations["assignee"] = None
+            else:
+                persons = await client.find_all("contact:class:Person")
+                query_lower = assignee.lower()
+                match = None
+                for p in persons:
+                    name: str = p.get("name", "")
+                    parts = name.split(",", 1)
+                    display = f"{parts[1].strip()} {parts[0].strip()}" if len(parts) == 2 else name
+                    if query_lower in display.lower() or query_lower in name.lower():
+                        match = p
+                        break
+                if match is None:
+                    raise NotFoundError(f"Person '{assignee}' not found.")
+                operations["assignee"] = match["_id"]
+
+        if not operations:
+            print_warning(
+                "No fields to update — provide at least one of --title, --status, --priority, --assignee."
+            )
+            return
+
+        transaction = {
+            "_class": "core:class:TxUpdateDoc",
+            "objectClass": "tracker:class:Issue",
+            "objectSpace": issue_space,
+            "objectId": issue_id,
+            "operations": operations,
+            "modifiedBy": auth.account_id,
+            "modifiedOn": int(time.time() * 1000),
+        }
+
+        await client.tx(transaction)
+
+
+@app.command("describe")
+def issues_describe(
+    ctx: typer.Context,
+    identifier: str = typer.Argument(..., help="Issue identifier (e.g. ROA-1)."),
+    raw: Annotated[
+        bool,
+        typer.Option("--raw", help="Show raw ProseMirror JSON instead of rendered markdown."),
+    ] = False,
+    set_text: Annotated[
+        str | None,
+        typer.Option("--set", help="Set description from markdown string."),
+    ] = None,
+    set_file: Annotated[
+        str | None,
+        typer.Option("--set-file", help="Set description from a markdown file path."),
+    ] = None,
+) -> None:
+    """Read or update the description of an issue.
+
+    By default, reads and displays the description. Use --set or --set-file to write.
+    """
+    if set_text and set_file:
+        print_error("Use either --set or --set-file, not both.")
+        raise typer.Exit(1)
+
+    # ── Write path ────────────────────────────────────────────────────────
+    if set_text is not None or set_file is not None:
+        markdown_content = set_text
+        if set_file is not None:
+            import pathlib
+
+            p = pathlib.Path(set_file)
+            if not p.exists():
+                print_error(f"File not found: {set_file}")
+                raise typer.Exit(1)
+            markdown_content = p.read_text(encoding="utf-8")
+
+        overrides: dict = ctx.obj or {}
+        config = load_config(
+            url_override=overrides.get("url"),
+            workspace_override=overrides.get("workspace"),
+        )
+
+        async def _write() -> str:
+            from huly_cli.markup import markdown_to_prosemirror
+
+            auth = await ensure_auth(config)
+            async with HulyClient(config, auth) as client:
+                raw_docs = await client.find_all(
+                    "tracker:class:Issue",
+                    query={"identifier": identifier.upper()},
+                    options={"limit": 1},
+                )
+                if not raw_docs:
+                    raise NotFoundError(f"Issue '{identifier}' not found.")
+                issue = Issue.model_validate(raw_docs[0])
+                if not issue.description:
+                    raise HulyError(
+                        f"Issue '{identifier}' has no description blob ref. "
+                        "Cannot update a description that was never created."
+                    )
+                markup = markdown_to_prosemirror(markdown_content or "")
+                ok = await client.set_description(issue.id, issue.description, markup)
+                if not ok:
+                    raise HulyError("Failed to update description via Collaborator RPC.")
+            return issue.identifier or identifier
+
+        try:
+            ident = asyncio.run(_write())
+        except NotFoundError as e:
+            print_error(e.message)
+            raise typer.Exit(1) from e
+        except AuthError as e:
+            print_error(e.message, hint="Run 'huly auth login' to authenticate.")
+            raise typer.Exit(2) from e
+        except HulyError as e:
+            print_error(e.message)
+            raise typer.Exit(1) from e
+
+        print_success(f"Description updated for {ident}.")
+        return
+
+    # ── Read path ─────────────────────────────────────────────────────────
+    overrides = ctx.obj or {}
+    config = load_config(
+        url_override=overrides.get("url"),
+        workspace_override=overrides.get("workspace"),
+    )
+
+    async def _run() -> tuple[str, str | None]:
+        auth = await ensure_auth(config)
+        async with HulyClient(config, auth) as client:
+            raw_docs = await client.find_all(
+                "tracker:class:Issue",
+                query={"identifier": identifier.upper()},
+                options={"limit": 1},
+            )
+            if not raw_docs:
+                raise NotFoundError(f"Issue '{identifier}' not found.")
+            issue = Issue.model_validate(raw_docs[0])
+            if not issue.description:
+                return issue.identifier or identifier, None
+            content = await client.get_description(issue.id, issue.description)
+        return issue.identifier or identifier, content
+
+    try:
+        ident, content = asyncio.run(_run())
+    except NotFoundError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+    except AuthError as e:
+        print_error(e.message, hint="Run 'huly auth login' to authenticate.")
+        raise typer.Exit(2) from e
+    except HulyError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+
+    if content is None:
+        print_error(f"No description available for issue '{ident}'.")
+        raise typer.Exit(1)
+
+    if is_json_mode():
+        if raw:
+            print(json.dumps({"ok": True, "identifier": ident, "description_raw": content}))
+        else:
+            from huly_cli.markup import prosemirror_to_markdown
+
+            md = prosemirror_to_markdown(content)
+            print(json.dumps({"ok": True, "identifier": ident, "description": md}))
+        return
+
+    if raw:
+        try:
+            parsed = json.loads(content)
+            console.print_json(json.dumps(parsed, indent=2))
+        except (json.JSONDecodeError, TypeError):
+            console.print(content)
+    else:
+        from rich.markdown import Markdown
+        from rich.panel import Panel
+
+        from huly_cli.markup import prosemirror_to_markdown
+
+        md_text = prosemirror_to_markdown(content)
+        if md_text.strip():
+            console.print(Panel(Markdown(md_text), title=f"Description: {ident}"))
+        else:
+            from huly_cli.markup import prosemirror_to_text
+
+            plain = prosemirror_to_text(content)
+            console.print(Panel(plain or "(empty description)", title=f"Description: {ident}"))

--- a/src/huly_cli/commands/labels.py
+++ b/src/huly_cli/commands/labels.py
@@ -1,0 +1,65 @@
+"""Labels commands: list."""
+
+from __future__ import annotations
+
+import asyncio
+from collections import Counter
+from typing import Any
+
+import typer
+
+from huly_cli.client import HulyClient
+from huly_cli.config import load_config
+from huly_cli.errors import AuthError, HulyError
+from huly_cli.models import TagReference
+from huly_cli.output import print_error, print_list
+
+app = typer.Typer(help="Manage issue labels.", no_args_is_help=True)
+
+
+@app.command("list")
+def labels_list(ctx: typer.Context) -> None:
+    """List available labels and how many issues use each."""
+    overrides: dict = ctx.obj or {}
+    config = load_config(
+        url_override=overrides.get("url"),
+        workspace_override=overrides.get("workspace"),
+    )
+
+    async def _run() -> list[dict[str, Any]]:
+        from huly_cli.auth import ensure_auth
+
+        auth = await ensure_auth(config)
+        async with HulyClient(config, auth) as client:
+            raw = await client.find_all("tags:class:TagReference", options={"limit": 1000})
+
+        tags = [TagReference.model_validate(doc) for doc in raw]
+
+        # Count how many issues reference each tag title
+        counts: Counter[str] = Counter(t.title for t in tags)
+
+        # Deduplicate by title, sorted alphabetically
+        seen: set[str] = set()
+        rows: list[dict[str, Any]] = []
+        for t in sorted(tags, key=lambda x: x.title.lower()):
+            if t.title in seen:
+                continue
+            seen.add(t.title)
+            rows.append(
+                {
+                    "title": t.title,
+                    "count": str(counts[t.title]),
+                }
+            )
+        return rows
+
+    try:
+        rows = asyncio.run(_run())
+    except AuthError as e:
+        print_error(e.message, hint="Run 'huly auth login' to authenticate.")
+        raise typer.Exit(2) from e
+    except HulyError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+
+    print_list(rows, columns=["title", "count"], title="Labels")

--- a/src/huly_cli/commands/members.py
+++ b/src/huly_cli/commands/members.py
@@ -1,0 +1,68 @@
+"""Members commands: list."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import typer
+
+from huly_cli.client import HulyClient
+from huly_cli.config import load_config
+from huly_cli.errors import AuthError, HulyError
+from huly_cli.models import Person, PersonAccount
+from huly_cli.output import print_error, print_list
+
+app = typer.Typer(help="Manage workspace members.", no_args_is_help=True)
+
+
+@app.command("list")
+def members_list(ctx: typer.Context) -> None:
+    """List workspace members with emails."""
+    overrides: dict = ctx.obj or {}
+    config = load_config(
+        url_override=overrides.get("url"),
+        workspace_override=overrides.get("workspace"),
+    )
+
+    async def _run() -> list[dict[str, Any]]:
+        from huly_cli.auth import ensure_auth
+
+        auth = await ensure_auth(config)
+        async with HulyClient(config, auth) as client:
+            raw_persons = await client.find_all("contact:class:Person", options={"limit": 500})
+            raw_accounts = await client.find_all(
+                "contact:class:PersonAccount", options={"limit": 500}
+            )
+
+        persons = [Person.model_validate(doc) for doc in raw_persons]
+        accounts = [PersonAccount.model_validate(doc) for doc in raw_accounts]
+
+        # Build map from person._id → email (from PersonAccount)
+        person_email: dict[str, str] = {}
+        for acc in accounts:
+            if acc.person and acc.email:
+                # Keep first email found per person
+                person_email.setdefault(acc.person, acc.email)
+
+        rows: list[dict[str, Any]] = []
+        for person in sorted(persons, key=lambda p: p.display_name):
+            rows.append(
+                {
+                    "name": person.display_name,
+                    "email": person_email.get(person.id, ""),
+                    "id": person.id,
+                }
+            )
+        return rows
+
+    try:
+        rows = asyncio.run(_run())
+    except AuthError as e:
+        print_error(e.message, hint="Run 'huly auth login' to authenticate.")
+        raise typer.Exit(2) from e
+    except HulyError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+
+    print_list(rows, columns=["name", "email", "id"], title="Members")

--- a/src/huly_cli/commands/milestones.py
+++ b/src/huly_cli/commands/milestones.py
@@ -1,0 +1,332 @@
+"""Milestones commands: list, get, create, update."""
+
+from __future__ import annotations
+
+import asyncio
+import datetime
+import secrets
+import time
+from typing import Annotated, Any
+
+import typer
+
+from huly_cli.auth import ensure_auth
+from huly_cli.client import HulyClient
+from huly_cli.config import load_config
+from huly_cli.errors import AuthError, HulyError, NotFoundError
+from huly_cli.models import MILESTONE_STATUS_FROM_NAME, Milestone
+from huly_cli.output import print_error, print_item, print_list, print_success, print_warning
+
+app = typer.Typer(help="Manage Huly milestones.", no_args_is_help=True)
+
+
+# ── Shared helpers ────────────────────────────────────────────────────────────
+
+
+async def _resolve_project_by_identifier(client: HulyClient, identifier: str) -> str:
+    """Return project_id for the given identifier."""
+    projects = await client.find_all(
+        "tracker:class:Project",
+        query={"identifier": identifier.upper()},
+        options={"limit": 1},
+    )
+    if not projects:
+        raise NotFoundError(f"Project '{identifier}' not found.")
+    return projects[0]["_id"]
+
+
+def _parse_date_ms(date_str: str) -> int:
+    """Parse a YYYY-MM-DD date string and return a UTC millisecond timestamp."""
+    dt = datetime.datetime.strptime(date_str, "%Y-%m-%d").replace(tzinfo=datetime.UTC)
+    return int(dt.timestamp() * 1000)
+
+
+def _format_date(ms: int | None) -> str:
+    """Format a millisecond UTC timestamp as YYYY-MM-DD, or '' if None."""
+    if ms is None:
+        return ""
+    dt = datetime.datetime.fromtimestamp(ms / 1000, tz=datetime.UTC)
+    return dt.strftime("%Y-%m-%d")
+
+
+def _milestone_to_row(m: Milestone) -> dict[str, Any]:
+    return {
+        "label": m.label,
+        "status": m.status_name,
+        "target_date": _format_date(m.target_date),
+        "id": m.id,
+    }
+
+
+def _milestone_to_detail(m: Milestone) -> dict[str, Any]:
+    return {
+        "label": m.label,
+        "id": m.id,
+        "space": m.space,
+        "status": m.status_name,
+        "status_int": m.status,
+        "target_date": _format_date(m.target_date),
+        "target_date_ms": m.target_date,
+        "comments": m.comments,
+        "created_by": m.created_by,
+        "modified_by": m.modified_by,
+    }
+
+
+def _resolve_status(status_name: str) -> int:
+    key = status_name.lower().replace(" ", "-")
+    val = MILESTONE_STATUS_FROM_NAME.get(key)
+    if val is None:
+        valid = ", ".join(MILESTONE_STATUS_FROM_NAME.keys())
+        raise HulyError(f"Unknown milestone status '{status_name}'. Valid values: {valid}")
+    return val
+
+
+# ── Commands ──────────────────────────────────────────────────────────────────
+
+
+@app.command("list")
+def milestones_list(
+    ctx: typer.Context,
+    project: Annotated[
+        str | None,
+        typer.Option("--project", "-p", help="Filter by project identifier (e.g. ROA)."),
+    ] = None,
+    status: Annotated[
+        str | None,
+        typer.Option("--status", "-s", help="Filter by status: planned, in-progress, completed."),
+    ] = None,
+    limit: Annotated[
+        int,
+        typer.Option("--limit", "-n", help="Maximum number of milestones to return."),
+    ] = 50,
+) -> None:
+    """List milestones, with optional project and status filters."""
+    overrides: dict = ctx.obj or {}
+    config = load_config(
+        url_override=overrides.get("url"),
+        workspace_override=overrides.get("workspace"),
+    )
+
+    async def _run() -> list[dict[str, Any]]:
+        auth = await ensure_auth(config)
+        async with HulyClient(config, auth) as client:
+            query: dict[str, Any] = {}
+
+            if status:
+                status_int = _resolve_status(status)
+                query["status"] = status_int
+
+            if project:
+                project_id = await _resolve_project_by_identifier(client, project)
+                query["space"] = project_id
+
+            raw = await client.find_all(
+                "tracker:class:Milestone",
+                query=query,
+                options={"limit": limit},
+            )
+            milestones = [Milestone.model_validate(doc) for doc in raw]
+
+        return [_milestone_to_row(m) for m in milestones]
+
+    try:
+        rows = asyncio.run(_run())
+    except AuthError as e:
+        print_error(e.message, hint="Run 'huly auth login' to authenticate.")
+        raise typer.Exit(2) from e
+    except HulyError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+
+    print_list(rows, columns=["label", "status", "target_date", "id"], title="Milestones")
+
+
+@app.command("get")
+def milestones_get(
+    ctx: typer.Context,
+    milestone_id: str = typer.Argument(..., help="Milestone internal ID."),
+) -> None:
+    """Get details of a milestone."""
+    overrides: dict = ctx.obj or {}
+    config = load_config(
+        url_override=overrides.get("url"),
+        workspace_override=overrides.get("workspace"),
+    )
+
+    async def _run() -> dict[str, Any]:
+        auth = await ensure_auth(config)
+        async with HulyClient(config, auth) as client:
+            raw = await client.find_all(
+                "tracker:class:Milestone",
+                query={"_id": milestone_id},
+                options={"limit": 1},
+            )
+            if not raw:
+                raise NotFoundError(f"Milestone '{milestone_id}' not found.")
+            milestone = Milestone.model_validate(raw[0])
+        return _milestone_to_detail(milestone)
+
+    try:
+        data = asyncio.run(_run())
+    except NotFoundError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+    except AuthError as e:
+        print_error(e.message, hint="Run 'huly auth login' to authenticate.")
+        raise typer.Exit(2) from e
+    except HulyError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+
+    print_item(data, title=f"Milestone: {data.get('label', milestone_id)}")
+
+
+@app.command("create")
+def milestones_create(
+    ctx: typer.Context,
+    label: Annotated[str, typer.Option("--label", help="Milestone label.")] = ...,
+    project: Annotated[
+        str, typer.Option("--project", help='Project identifier (e.g. "ROA").')
+    ] = ...,
+    status: Annotated[
+        str, typer.Option("--status", help="Status: planned, in-progress, completed.")
+    ] = "planned",
+    target_date: Annotated[
+        str | None, typer.Option("--target-date", help="Target date (YYYY-MM-DD).")
+    ] = None,
+) -> None:
+    """Create a new milestone."""
+    overrides: dict = ctx.obj or {}
+    config = load_config(
+        url_override=overrides.get("url"),
+        workspace_override=overrides.get("workspace"),
+    )
+
+    async def _run() -> str:
+        auth = await ensure_auth(config)
+        async with HulyClient(config, auth) as client:
+            project_id = await _resolve_project_by_identifier(client, project)
+
+            status_int = _resolve_status(status)
+
+            target_date_ms: int | None = None
+            if target_date:
+                try:
+                    target_date_ms = _parse_date_ms(target_date)
+                except ValueError:
+                    raise HulyError(
+                        f"Invalid date format '{target_date}'. Use YYYY-MM-DD."
+                    ) from None
+
+            new_id = secrets.token_hex(12)
+
+            transaction = {
+                "_class": "core:class:TxCreateDoc",
+                "objectClass": "tracker:class:Milestone",
+                "objectSpace": project_id,
+                "objectId": new_id,
+                "attributes": {
+                    "label": label,
+                    "status": status_int,
+                    "targetDate": target_date_ms,
+                    "comments": 0,
+                },
+                "modifiedBy": auth.account_id,
+                "modifiedOn": int(time.time() * 1000),
+            }
+
+            await client.tx(transaction)
+        return new_id
+
+    try:
+        new_id = asyncio.run(_run())
+        print_success(f"Milestone created in project '{project}' (id: {new_id})")
+    except NotFoundError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+    except AuthError as e:
+        print_error(e.message, hint="Run 'huly auth login' to authenticate.")
+        raise typer.Exit(2) from e
+    except HulyError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+
+
+@app.command("update")
+def milestones_update(
+    ctx: typer.Context,
+    milestone_id: str = typer.Argument(..., help="Milestone internal ID."),
+    label: Annotated[str | None, typer.Option("--label", help="New milestone label.")] = None,
+    status: Annotated[
+        str | None, typer.Option("--status", help="New status: planned, in-progress, completed.")
+    ] = None,
+    target_date: Annotated[
+        str | None, typer.Option("--target-date", help="New target date (YYYY-MM-DD).")
+    ] = None,
+) -> None:
+    """Update an existing milestone."""
+    overrides: dict = ctx.obj or {}
+    config = load_config(
+        url_override=overrides.get("url"),
+        workspace_override=overrides.get("workspace"),
+    )
+
+    async def _run() -> None:
+        auth = await ensure_auth(config)
+        async with HulyClient(config, auth) as client:
+            raw = await client.find_all(
+                "tracker:class:Milestone",
+                query={"_id": milestone_id},
+                options={"limit": 1},
+            )
+            if not raw:
+                raise NotFoundError(f"Milestone '{milestone_id}' not found.")
+            milestone = Milestone.model_validate(raw[0])
+
+            operations: dict = {}
+
+            if label is not None:
+                operations["label"] = label
+
+            if status is not None:
+                operations["status"] = _resolve_status(status)
+
+            if target_date is not None:
+                try:
+                    operations["targetDate"] = _parse_date_ms(target_date)
+                except ValueError:
+                    raise HulyError(
+                        f"Invalid date format '{target_date}'. Use YYYY-MM-DD."
+                    ) from None
+
+            if not operations:
+                print_warning(
+                    "No fields to update — provide at least one of --label, --status, --target-date."
+                )
+                return
+
+            transaction = {
+                "_class": "core:class:TxUpdateDoc",
+                "objectClass": "tracker:class:Milestone",
+                "objectSpace": milestone.space,
+                "objectId": milestone.id,
+                "operations": operations,
+                "modifiedBy": auth.account_id,
+                "modifiedOn": int(time.time() * 1000),
+            }
+
+            await client.tx(transaction)
+
+    try:
+        asyncio.run(_run())
+        print_success(f"Milestone {milestone_id} updated.")
+    except NotFoundError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+    except AuthError as e:
+        print_error(e.message, hint="Run 'huly auth login' to authenticate.")
+        raise typer.Exit(2) from e
+    except HulyError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e

--- a/src/huly_cli/commands/projects.py
+++ b/src/huly_cli/commands/projects.py
@@ -1,0 +1,115 @@
+"""Projects commands: list, get."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import typer
+
+from huly_cli.client import HulyClient
+from huly_cli.config import load_config
+from huly_cli.errors import AuthError, HulyError, NotFoundError
+from huly_cli.models import Project
+from huly_cli.output import print_error, print_item, print_list
+
+app = typer.Typer(help="Manage Huly projects.", no_args_is_help=True)
+
+
+# ── Async helpers ─────────────────────────────────────────────────────────────
+
+
+async def _fetch_projects(config: Any, auth: Any) -> list[Project]:
+    async with HulyClient(config, auth) as client:
+        raw = await client.find_all("tracker:class:Project", options={"limit": 200})
+    return [Project.model_validate(doc) for doc in raw]
+
+
+# ── Commands ──────────────────────────────────────────────────────────────────
+
+
+@app.command("list")
+def projects_list(ctx: typer.Context) -> None:
+    """List all projects."""
+    overrides: dict = ctx.obj or {}
+    config = load_config(
+        url_override=overrides.get("url"),
+        workspace_override=overrides.get("workspace"),
+    )
+
+    async def _run() -> list[Project]:
+        from huly_cli.auth import ensure_auth
+
+        auth = await ensure_auth(config)
+        return await _fetch_projects(config, auth)
+
+    try:
+        projects = asyncio.run(_run())
+    except AuthError as e:
+        print_error(e.message, hint="Run 'huly auth login' to authenticate.")
+        raise typer.Exit(2) from e
+    except HulyError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+
+    rows = [
+        {
+            "identifier": p.identifier or p.id,
+            "name": p.name,
+            "members": str(len(p.members)),
+            "archived": "yes" if p.archived else "no",
+        }
+        for p in projects
+    ]
+    print_list(rows, columns=["identifier", "name", "members", "archived"], title="Projects")
+
+
+@app.command("get")
+def projects_get(
+    ctx: typer.Context,
+    identifier: str = typer.Argument(..., help="Project identifier (e.g. ROA) or internal ID."),
+) -> None:
+    """Get details of a project."""
+    overrides: dict = ctx.obj or {}
+    config = load_config(
+        url_override=overrides.get("url"),
+        workspace_override=overrides.get("workspace"),
+    )
+
+    async def _run() -> Project:
+        from huly_cli.auth import ensure_auth
+
+        auth = await ensure_auth(config)
+        projects = await _fetch_projects(config, auth)
+        # Match by identifier or internal ID
+        ident_upper = identifier.upper()
+        for p in projects:
+            if p.identifier.upper() == ident_upper or p.id == identifier:
+                return p
+        raise NotFoundError(f"Project '{identifier}' not found.")
+
+    try:
+        project = asyncio.run(_run())
+    except NotFoundError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+    except AuthError as e:
+        print_error(e.message, hint="Run 'huly auth login' to authenticate.")
+        raise typer.Exit(2) from e
+    except HulyError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+
+    data = {
+        "identifier": project.identifier,
+        "name": project.name,
+        "id": project.id,
+        "description": project.description,
+        "sequence": project.sequence,
+        "members": project.members,
+        "owners": project.owners,
+        "default_issue_status": project.default_issue_status,
+        "private": project.private,
+        "archived": project.archived,
+    }
+    print_item(data, title=f"Project: {project.identifier or project.name}")

--- a/src/huly_cli/commands/templates.py
+++ b/src/huly_cli/commands/templates.py
@@ -1,0 +1,342 @@
+"""Templates commands: list, get, describe."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Annotated, Any
+
+import typer
+
+from huly_cli.auth import ensure_auth
+from huly_cli.client import HulyClient
+from huly_cli.config import load_config
+from huly_cli.errors import AuthError, HulyError, NotFoundError
+from huly_cli.models import IssueTemplate
+from huly_cli.output import (
+    console,
+    is_json_mode,
+    print_error,
+    print_item,
+    print_list,
+    print_success,
+    print_warning,
+)
+
+app = typer.Typer(help="Manage Huly issue templates.", no_args_is_help=True)
+
+
+# ── Shared helpers ────────────────────────────────────────────────────────────
+
+
+def _template_to_row(t: IssueTemplate) -> dict[str, Any]:
+    return {
+        "title": t.title,
+        "priority": t.priority_name,
+        "kind": t.kind,
+        "id": t.id,
+    }
+
+
+def _template_to_detail(t: IssueTemplate) -> dict[str, Any]:
+    return {
+        "title": t.title,
+        "id": t.id,
+        "space": t.space,
+        "priority": t.priority_name,
+        "priority_int": t.priority,
+        "kind": t.kind,
+        "assignee": t.assignee,
+        "component": t.component,
+        "milestone": t.milestone,
+        "estimation": t.estimation,
+        "comments": t.comments,
+        "attachments": t.attachments,
+        "labels": t.labels,
+        "children": len(t.children),
+        "relations": len(t.relations),
+    }
+
+
+# ── Commands ──────────────────────────────────────────────────────────────────
+
+
+@app.command("list")
+def templates_list(
+    ctx: typer.Context,
+    project: Annotated[
+        str | None,
+        typer.Option("--project", "-p", help="Filter by project identifier (e.g. ROA)."),
+    ] = None,
+    limit: Annotated[
+        int,
+        typer.Option("--limit", "-n", help="Maximum number of templates to return."),
+    ] = 50,
+) -> None:
+    """List issue templates, with optional project filter."""
+    overrides: dict = ctx.obj or {}
+    config = load_config(
+        url_override=overrides.get("url"),
+        workspace_override=overrides.get("workspace"),
+    )
+
+    async def _run() -> list[dict[str, Any]]:
+        auth = await ensure_auth(config)
+        async with HulyClient(config, auth) as client:
+            query: dict[str, Any] = {}
+            if project:
+                projects = await client.find_all(
+                    "tracker:class:Project",
+                    query={"identifier": project.upper()},
+                    options={"limit": 1},
+                )
+                if not projects:
+                    raise NotFoundError(f"Project '{project}' not found.")
+                query["space"] = projects[0]["_id"]
+
+            raw = await client.find_all(
+                "tracker:class:IssueTemplate",
+                query=query,
+                options={"limit": limit},
+            )
+            templates = [IssueTemplate.model_validate(doc) for doc in raw]
+
+        return [_template_to_row(t) for t in templates]
+
+    try:
+        rows = asyncio.run(_run())
+    except AuthError as e:
+        print_error(e.message, hint="Run 'huly auth login' to authenticate.")
+        raise typer.Exit(2) from e
+    except HulyError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+
+    print_list(rows, columns=["title", "priority", "kind", "id"], title="Issue Templates")
+
+
+@app.command("get")
+def templates_get(
+    ctx: typer.Context,
+    template_id: str = typer.Argument(..., help="Template internal ID."),
+) -> None:
+    """Get details of an issue template."""
+    overrides: dict = ctx.obj or {}
+    config = load_config(
+        url_override=overrides.get("url"),
+        workspace_override=overrides.get("workspace"),
+    )
+
+    async def _run() -> dict[str, Any]:
+        auth = await ensure_auth(config)
+        async with HulyClient(config, auth) as client:
+            raw = await client.find_all(
+                "tracker:class:IssueTemplate",
+                query={"_id": template_id},
+                options={"limit": 1},
+            )
+            if not raw:
+                raise NotFoundError(f"Template '{template_id}' not found.")
+            template = IssueTemplate.model_validate(raw[0])
+        return _template_to_detail(template)
+
+    try:
+        data = asyncio.run(_run())
+    except NotFoundError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+    except AuthError as e:
+        print_error(e.message, hint="Run 'huly auth login' to authenticate.")
+        raise typer.Exit(2) from e
+    except HulyError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+
+    print_item(data, title=f"Template: {data.get('title', template_id)}")
+
+
+@app.command("describe")
+def templates_describe(
+    ctx: typer.Context,
+    template_id: str = typer.Argument(..., help="Template internal ID."),
+    raw: Annotated[
+        bool,
+        typer.Option("--raw", help="Show raw ProseMirror JSON instead of rendered markdown."),
+    ] = False,
+    set_text: Annotated[
+        str | None,
+        typer.Option("--set", help="Set description from markdown string."),
+    ] = None,
+    set_file: Annotated[
+        str | None,
+        typer.Option("--set-file", help="Set description from a markdown file path."),
+    ] = None,
+) -> None:
+    """Read or update the description of an issue template.
+
+    Template descriptions are stored as inline ProseMirror JSON (not a blob ref).
+    By default, reads and displays the description. Use --set or --set-file to write.
+    """
+    if set_text and set_file:
+        print_error("Use either --set or --set-file, not both.")
+        raise typer.Exit(1)
+
+    overrides: dict = ctx.obj or {}
+    config = load_config(
+        url_override=overrides.get("url"),
+        workspace_override=overrides.get("workspace"),
+    )
+
+    # ── Write path ────────────────────────────────────────────────────────
+    if set_text is not None or set_file is not None:
+        markdown_content = set_text
+        if set_file is not None:
+            import pathlib
+
+            p = pathlib.Path(set_file)
+            if not p.exists():
+                print_error(f"File not found: {set_file}")
+                raise typer.Exit(1)
+            markdown_content = p.read_text(encoding="utf-8")
+
+        async def _write() -> str:
+            import time as time_mod
+
+            from huly_cli.markup import markdown_to_prosemirror
+
+            auth = await ensure_auth(config)
+            async with HulyClient(config, auth) as client:
+                raw_docs = await client.find_all(
+                    "tracker:class:IssueTemplate",
+                    query={"_id": template_id},
+                    options={"limit": 1},
+                )
+                if not raw_docs:
+                    raise NotFoundError(f"Template '{template_id}' not found.")
+                template = IssueTemplate.model_validate(raw_docs[0])
+
+                # Safety: detect if description looks like a blob ref string
+                if (
+                    isinstance(template.description, str)
+                    and "-description-" in template.description
+                ):
+                    raise HulyError(
+                        f"Template '{template_id}' description looks like a blob ref "
+                        f"(contains '-description-'). Aborting to avoid corruption."
+                    )
+
+                markup_json_str = markdown_to_prosemirror(markdown_content or "")
+                description_dict = json.loads(markup_json_str)
+
+                transaction = {
+                    "_class": "core:class:TxUpdateDoc",
+                    "objectClass": "tracker:class:IssueTemplate",
+                    "objectSpace": template.space,
+                    "objectId": template.id,
+                    "operations": {"description": description_dict},
+                    "modifiedBy": auth.account_id,
+                    "modifiedOn": int(time_mod.time() * 1000),
+                }
+                await client.tx(transaction)
+            return template.title or template_id
+
+        try:
+            title_label = asyncio.run(_write())
+        except NotFoundError as e:
+            print_error(e.message)
+            raise typer.Exit(1) from e
+        except AuthError as e:
+            print_error(e.message, hint="Run 'huly auth login' to authenticate.")
+            raise typer.Exit(2) from e
+        except HulyError as e:
+            print_error(e.message)
+            raise typer.Exit(1) from e
+
+        print_success(f"Description updated for '{title_label}'.")
+        return
+
+    # ── Read path ─────────────────────────────────────────────────────────
+    async def _run() -> tuple[str, Any]:
+        auth = await ensure_auth(config)
+        async with HulyClient(config, auth) as client:
+            raw_docs = await client.find_all(
+                "tracker:class:IssueTemplate",
+                query={"_id": template_id},
+                options={"limit": 1},
+            )
+            if not raw_docs:
+                raise NotFoundError(f"Template '{template_id}' not found.")
+            template = IssueTemplate.model_validate(raw_docs[0])
+        return template.title or template_id, template.description
+
+    try:
+        title_label, description = asyncio.run(_run())
+    except NotFoundError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+    except AuthError as e:
+        print_error(e.message, hint="Run 'huly auth login' to authenticate.")
+        raise typer.Exit(2) from e
+    except HulyError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+
+    if not description:
+        print_error(f"No description available for template '{title_label}'.")
+        raise typer.Exit(1)
+
+    # Safety: detect blob ref string
+    if isinstance(description, str) and "-description-" in description:
+        print_warning(
+            f"Template '{title_label}' description looks like a blob ref — "
+            "this template may use a non-standard storage format."
+        )
+
+    # Normalise: description may be a dict (from API) or a string
+    if isinstance(description, dict):
+        raw_json_str = json.dumps(description)
+    else:
+        raw_json_str = str(description)
+
+    if is_json_mode():
+        if raw:
+            print(
+                json.dumps(
+                    {
+                        "ok": True,
+                        "id": template_id,
+                        "description_raw": json.loads(raw_json_str)
+                        if isinstance(description, dict)
+                        else raw_json_str,
+                    }
+                )
+            )
+        else:
+            from huly_cli.markup import prosemirror_to_markdown
+
+            md = prosemirror_to_markdown(raw_json_str)
+            print(json.dumps({"ok": True, "id": template_id, "description": md}))
+        return
+
+    if raw:
+        try:
+            parsed = json.loads(raw_json_str)
+            console.print_json(json.dumps(parsed, indent=2))
+        except (json.JSONDecodeError, TypeError):
+            console.print(raw_json_str)
+    else:
+        from rich.markdown import Markdown
+        from rich.panel import Panel
+
+        from huly_cli.markup import prosemirror_to_markdown
+
+        md_text = prosemirror_to_markdown(raw_json_str)
+        if md_text.strip():
+            console.print(Panel(Markdown(md_text), title=f"Description: {title_label}"))
+        else:
+            from huly_cli.markup import prosemirror_to_text
+
+            plain = prosemirror_to_text(raw_json_str)
+            console.print(
+                Panel(plain or "(empty description)", title=f"Description: {title_label}")
+            )

--- a/src/huly_cli/main.py
+++ b/src/huly_cli/main.py
@@ -6,7 +6,17 @@ from typing import Annotated
 
 import typer
 
-from huly_cli.commands import auth_cmd, issues, labels, members, projects
+from huly_cli.commands import (
+    auth_cmd,
+    components,
+    documents,
+    issues,
+    labels,
+    members,
+    milestones,
+    projects,
+    templates,
+)
 from huly_cli.errors import HulyError, handle_error
 from huly_cli.output import set_json_mode
 
@@ -22,6 +32,10 @@ app.add_typer(projects.app, name="projects")
 app.add_typer(issues.app, name="issues")
 app.add_typer(members.app, name="members")
 app.add_typer(labels.app, name="labels")
+app.add_typer(documents.app, name="documents")
+app.add_typer(components.app, name="components")
+app.add_typer(milestones.app, name="milestones")
+app.add_typer(templates.app, name="templates")
 
 
 @app.callback()

--- a/src/huly_cli/main.py
+++ b/src/huly_cli/main.py
@@ -6,7 +6,7 @@ from typing import Annotated
 
 import typer
 
-from huly_cli.commands import auth_cmd
+from huly_cli.commands import auth_cmd, issues, labels, members, projects
 from huly_cli.errors import HulyError, handle_error
 from huly_cli.output import set_json_mode
 
@@ -18,6 +18,10 @@ app = typer.Typer(
 )
 
 app.add_typer(auth_cmd.app, name="auth")
+app.add_typer(projects.app, name="projects")
+app.add_typer(issues.app, name="issues")
+app.add_typer(members.app, name="members")
+app.add_typer(labels.app, name="labels")
 
 
 @app.callback()

--- a/src/huly_cli/models.py
+++ b/src/huly_cli/models.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from enum import IntEnum
+from typing import Any
 
 from pydantic import BaseModel, Field
 
@@ -114,3 +115,130 @@ class TagReference(BaseModel):
     tag: str
     title: str
     attached_to: str = Field("", alias="attachedTo")
+
+
+# ── Document / Teamspace ──────────────────────────────────────────────────────
+
+
+class Teamspace(BaseModel):
+    model_config = {"populate_by_name": True}
+
+    id: str = Field(alias="_id")
+    name: str
+    description: str = ""
+    private: bool = False
+    archived: bool = False
+    members: list[str] = []
+    owners: list[str] = []
+
+
+class Document(BaseModel):
+    """A Huly document stored in a Teamspace (document:class:Document)."""
+
+    model_config = {"populate_by_name": True}
+
+    id: str = Field(alias="_id")
+    title: str = ""
+    content: str = ""  # blob ref (empty string if no content yet)
+    space: str = ""
+    parent: str = Field("", alias="parent")
+    attachments: int = 0
+    labels: int = 0
+    comments: int = 0
+    rank: str = ""
+    created_by: str = Field("", alias="createdBy")
+    created_on: int = Field(0, alias="createdOn")
+    modified_by: str = Field("", alias="modifiedBy")
+    modified_on: int = Field(0, alias="modifiedOn")
+
+
+# ── Component ─────────────────────────────────────────────────────────────────
+
+
+class Component(BaseModel):
+    """A tracker component scoped to a project (tracker:class:Component)."""
+
+    model_config = {"populate_by_name": True}
+
+    id: str = Field(alias="_id")
+    label: str = ""
+    description: str = ""
+    lead: str | None = None  # Person ID
+    space: str = ""
+    created_by: str = Field("", alias="createdBy")
+    created_on: int = Field(0, alias="createdOn")
+    modified_by: str = Field("", alias="modifiedBy")
+    modified_on: int = Field(0, alias="modifiedOn")
+
+
+# ── Milestone ─────────────────────────────────────────────────────────────────
+
+
+class MilestoneStatus(IntEnum):
+    PLANNED = 0
+    IN_PROGRESS = 1
+    COMPLETED = 2
+    CANCELLED = 3
+
+
+MILESTONE_STATUS_LABELS: dict[int, str] = {
+    0: "planned",
+    1: "in-progress",
+    2: "completed",
+    3: "cancelled",
+}
+
+MILESTONE_STATUS_FROM_NAME: dict[str, int] = {v: k for k, v in MILESTONE_STATUS_LABELS.items()}
+
+
+class Milestone(BaseModel):
+    """A tracker milestone scoped to a project (tracker:class:Milestone)."""
+
+    model_config = {"populate_by_name": True}
+
+    id: str = Field(alias="_id")
+    label: str = ""
+    status: int = 0
+    target_date: int | None = Field(None, alias="targetDate")
+    comments: int = 0
+    space: str = ""
+    created_by: str = Field("", alias="createdBy")
+    created_on: int = Field(0, alias="createdOn")
+    modified_by: str = Field("", alias="modifiedBy")
+    modified_on: int = Field(0, alias="modifiedOn")
+
+    @property
+    def status_name(self) -> str:
+        return MILESTONE_STATUS_LABELS.get(self.status, str(self.status))
+
+
+# ── IssueTemplate ─────────────────────────────────────────────────────────────
+
+
+class IssueTemplate(BaseModel):
+    """An issue template (tracker:class:IssueTemplate).
+
+    The description field stores inline ProseMirror JSON (dict), not a blob ref.
+    """
+
+    model_config = {"populate_by_name": True}
+
+    id: str = Field(alias="_id")
+    title: str = ""
+    description: Any = None  # inline ProseMirror dict or empty string
+    assignee: str | None = None
+    component: str | None = None
+    milestone: str | None = None
+    priority: int = 0
+    estimation: int = 0
+    children: list[Any] = []
+    comments: int = 0
+    attachments: int = 0
+    labels: int = 0
+    kind: str = ""
+    relations: list[Any] = []
+    space: str = ""
+
+    @property
+    def priority_name(self) -> str:
+        return PRIORITY_LABELS.get(self.priority, str(self.priority))

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -287,3 +287,114 @@ def test_issues_list_json_mode():
     assert data["ok"] is True
     assert len(data["data"]) == 1
     assert data["data"][0]["title"] == "Fix bug"
+
+
+# ── documents list ─────────────────────────────────────────────────────────────
+
+DOCUMENT_DATA = [
+    {
+        "_id": "doc1",
+        "title": "My Doc",
+        "content": "blob-ref-123",
+        "space": "ts1",
+        "parent": "document:ids:NoParent",
+        "attachments": 0,
+        "labels": 0,
+        "comments": 0,
+        "rank": "",
+        "createdBy": "",
+        "createdOn": 0,
+        "modifiedBy": "",
+        "modifiedOn": 0,
+    }
+]
+
+TEAMSPACE_DATA = [
+    {
+        "_id": "ts1",
+        "name": "Engineering",
+        "description": "",
+        "private": False,
+        "archived": False,
+        "members": [],
+        "owners": [],
+    }
+]
+
+
+def test_documents_list():
+    # find_all called twice: once for teamspaces, once for documents
+    find_mock = AsyncMock(side_effect=[TEAMSPACE_DATA, DOCUMENT_DATA])
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["documents", "list"])
+    assert result.exit_code == 0, result.output
+    assert "My Doc" in result.output
+
+
+def test_documents_list_empty():
+    find_mock = AsyncMock(side_effect=[TEAMSPACE_DATA, []])
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["documents", "list"])
+    assert result.exit_code == 0
+
+
+def test_documents_list_shows_space():
+    find_mock = AsyncMock(side_effect=[TEAMSPACE_DATA, DOCUMENT_DATA])
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["documents", "list"])
+    assert result.exit_code == 0, result.output
+    assert "Engineering" in result.output
+
+
+# ── components list ────────────────────────────────────────────────────────────
+
+COMPONENT_DATA = [
+    {
+        "_id": "c1",
+        "label": "Auth Service",
+        "description": "Handles authentication",
+        "lead": None,
+        "space": "proj1",
+        "createdBy": "",
+        "createdOn": 0,
+        "modifiedBy": "",
+        "modifiedOn": 0,
+    }
+]
+
+
+def test_components_list():
+    # find_all called twice: once for components, once for persons
+    find_mock = AsyncMock(side_effect=[COMPONENT_DATA, []])
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["components", "list"])
+    assert result.exit_code == 0, result.output
+    assert "Auth Service" in result.output
+
+
+def test_components_list_empty():
+    find_mock = AsyncMock(side_effect=[[], []])
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["components", "list"])
+    assert result.exit_code == 0
+
+
+def test_components_list_shows_description():
+    find_mock = AsyncMock(side_effect=[COMPONENT_DATA, []])
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["components", "list"])
+    assert result.exit_code == 0, result.output
+    assert "Auth Service" in result.output
+
+
+def test_components_list_json_mode():
+    import json as json_mod
+
+    find_mock = AsyncMock(side_effect=[COMPONENT_DATA, []])
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["--json", "components", "list"])
+    assert result.exit_code == 0, result.output
+    data = json_mod.loads(result.output)
+    assert data["ok"] is True
+    assert isinstance(data["data"], list)
+    assert data["data"][0]["label"] == "Auth Service"

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,0 +1,289 @@
+"""Regression tests for CLI commands using typer CliRunner + mocked auth/client."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+from typer.testing import CliRunner
+
+from huly_cli.config import AuthCache
+from huly_cli.main import app
+
+runner = CliRunner()
+
+FAKE_AUTH = AuthCache(
+    account_token="t",
+    workspace_token="t",
+    workspace_id="w",
+    workspace_uuid="u",
+    email="test@test.com",
+    workspace_slug="test",
+    account_id="a",
+    cached_at=1.0,
+)
+
+
+def _auth_patch():
+    """Patch ensure_auth to return FAKE_AUTH directly (used by all sub-commands)."""
+    return patch("huly_cli.auth.ensure_auth", new=AsyncMock(return_value=FAKE_AUTH))
+
+
+# ── projects list ──────────────────────────────────────────────────────────────
+
+
+def test_projects_list():
+    project_data = [
+        {
+            "_id": "p1",
+            "name": "Test Project",
+            "identifier": "TP",
+            "members": ["a1"],
+            "owners": [],
+            "sequence": 5,
+            "description": "",
+            "defaultIssueStatus": "",
+            "private": False,
+            "archived": False,
+        }
+    ]
+    find_mock = AsyncMock(return_value=project_data)
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["projects", "list"])
+    assert result.exit_code == 0, result.output
+    assert "Test Project" in result.output
+
+
+def test_projects_list_shows_identifier():
+    project_data = [
+        {
+            "_id": "p2",
+            "name": "Another Project",
+            "identifier": "AP",
+            "members": ["a1", "a2"],
+            "owners": [],
+            "sequence": 1,
+            "description": "",
+            "defaultIssueStatus": "",
+            "private": False,
+            "archived": False,
+        }
+    ]
+    find_mock = AsyncMock(return_value=project_data)
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["projects", "list"])
+    assert result.exit_code == 0, result.output
+    assert "AP" in result.output
+
+
+def test_projects_list_empty():
+    find_mock = AsyncMock(return_value=[])
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["projects", "list"])
+    assert result.exit_code == 0
+
+
+# ── issues list ────────────────────────────────────────────────────────────────
+
+
+ISSUE_DATA = [
+    {
+        "_id": "i1",
+        "title": "Fix bug",
+        "identifier": "TP-1",
+        "number": 1,
+        "status": "tracker:status:Backlog",
+        "priority": 2,
+        "assignee": None,
+        "description": "",
+        "kind": "",
+        "createdBy": "",
+        "createdOn": 0,
+        "modifiedBy": "",
+        "modifiedOn": 0,
+        "estimation": 0,
+        "labels": 0,
+        "comments": 0,
+        "subIssues": 0,
+        "space": "p1",
+        "dueDate": None,
+    }
+]
+
+
+def test_issues_list():
+    # find_all is called twice: once for issues, once for persons
+    find_mock = AsyncMock(side_effect=[ISSUE_DATA, []])
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["issues", "list"])
+    assert result.exit_code == 0, result.output
+    assert "Fix bug" in result.output
+
+
+def test_issues_list_shows_identifier():
+    find_mock = AsyncMock(side_effect=[ISSUE_DATA, []])
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["issues", "list"])
+    assert result.exit_code == 0, result.output
+    assert "TP-1" in result.output
+
+
+def test_issues_list_shows_status():
+    find_mock = AsyncMock(side_effect=[ISSUE_DATA, []])
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["issues", "list"])
+    assert result.exit_code == 0, result.output
+    assert "backlog" in result.output.lower()
+
+
+def test_issues_list_empty():
+    find_mock = AsyncMock(side_effect=[[], []])
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["issues", "list"])
+    assert result.exit_code == 0
+
+
+# ── members list ───────────────────────────────────────────────────────────────
+
+
+def test_members_list():
+    find_mock = AsyncMock(
+        side_effect=[
+            [{"_id": "person1", "name": "Doe,John"}],  # persons
+            [{"_id": "acc1", "person": "person1", "email": "john@test.com"}],  # accounts
+        ]
+    )
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["members", "list"])
+    assert result.exit_code == 0, result.output
+    assert "John Doe" in result.output
+
+
+def test_members_list_shows_email():
+    find_mock = AsyncMock(
+        side_effect=[
+            [{"_id": "p1", "name": "Smith,Jane"}],
+            [{"_id": "a1", "person": "p1", "email": "jane@example.com"}],
+        ]
+    )
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["members", "list"])
+    assert result.exit_code == 0, result.output
+    assert "jane@example.com" in result.output
+
+
+def test_members_list_empty():
+    find_mock = AsyncMock(side_effect=[[], []])
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["members", "list"])
+    assert result.exit_code == 0
+
+
+def test_members_list_no_email():
+    """Member with no matching account should show empty email."""
+    find_mock = AsyncMock(
+        side_effect=[
+            [{"_id": "p99", "name": "Solo,Player"}],
+            [],  # no accounts
+        ]
+    )
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["members", "list"])
+    assert result.exit_code == 0, result.output
+    assert "Player Solo" in result.output
+
+
+# ── labels list ────────────────────────────────────────────────────────────────
+
+
+def test_labels_list():
+    tag_data = [
+        {"_id": "t1", "tag": "tag1", "title": "Sprint 1", "attachedTo": "i1"},
+        {"_id": "t2", "tag": "tag1", "title": "Sprint 1", "attachedTo": "i2"},
+    ]
+    find_mock = AsyncMock(return_value=tag_data)
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["labels", "list"])
+    assert result.exit_code == 0, result.output
+    assert "Sprint 1" in result.output
+
+
+def test_labels_list_count():
+    """Labels with multiple uses should show correct count."""
+    tag_data = [
+        {"_id": "t1", "tag": "tag1", "title": "Bug", "attachedTo": "i1"},
+        {"_id": "t2", "tag": "tag1", "title": "Bug", "attachedTo": "i2"},
+        {"_id": "t3", "tag": "tag1", "title": "Bug", "attachedTo": "i3"},
+        {"_id": "t4", "tag": "tag2", "title": "Feature", "attachedTo": "i4"},
+    ]
+    find_mock = AsyncMock(return_value=tag_data)
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["labels", "list"])
+    assert result.exit_code == 0, result.output
+    assert "Bug" in result.output
+    assert "Feature" in result.output
+    # Count for Bug should be 3
+    assert "3" in result.output
+
+
+def test_labels_list_deduplicates():
+    """Each label should only appear once even if used multiple times."""
+    tag_data = [
+        {"_id": "t1", "tag": "tag1", "title": "Sprint 1", "attachedTo": "i1"},
+        {"_id": "t2", "tag": "tag1", "title": "Sprint 1", "attachedTo": "i2"},
+        {"_id": "t3", "tag": "tag1", "title": "Sprint 1", "attachedTo": "i3"},
+    ]
+    find_mock = AsyncMock(return_value=tag_data)
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["labels", "list"])
+    assert result.exit_code == 0, result.output
+    # "Sprint 1" should only appear once in the output
+    assert result.output.count("Sprint 1") == 1
+
+
+def test_labels_list_empty():
+    find_mock = AsyncMock(return_value=[])
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["labels", "list"])
+    assert result.exit_code == 0
+
+
+# ── JSON output mode ───────────────────────────────────────────────────────────
+
+
+def test_projects_list_json_mode():
+    import json as json_mod
+
+    project_data = [
+        {
+            "_id": "p1",
+            "name": "Test Project",
+            "identifier": "TP",
+            "members": [],
+            "owners": [],
+            "sequence": 0,
+            "description": "",
+            "defaultIssueStatus": "",
+            "private": False,
+            "archived": False,
+        }
+    ]
+    find_mock = AsyncMock(return_value=project_data)
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["--json", "projects", "list"])
+    assert result.exit_code == 0, result.output
+    data = json_mod.loads(result.output)
+    assert data["ok"] is True
+    assert isinstance(data["data"], list)
+
+
+def test_issues_list_json_mode():
+    import json as json_mod
+
+    find_mock = AsyncMock(side_effect=[ISSUE_DATA, []])
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["--json", "issues", "list"])
+    assert result.exit_code == 0, result.output
+    data = json_mod.loads(result.output)
+    assert data["ok"] is True
+    assert len(data["data"]) == 1
+    assert data["data"][0]["title"] == "Fix bug"

--- a/tests/test_commands_new.py
+++ b/tests/test_commands_new.py
@@ -1,0 +1,240 @@
+"""Regression tests for milestones and templates CLI commands."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+from typer.testing import CliRunner
+
+from huly_cli.config import AuthCache
+from huly_cli.main import app
+
+runner = CliRunner()
+
+FAKE_AUTH = AuthCache(
+    account_token="t",
+    workspace_token="t",
+    workspace_id="w",
+    workspace_uuid="u",
+    email="test@test.com",
+    workspace_slug="test",
+    account_id="a",
+    cached_at=1.0,
+)
+
+
+def _auth_patch():
+    """Patch ensure_auth to return FAKE_AUTH directly (used by all sub-commands)."""
+    return patch("huly_cli.auth.ensure_auth", new=AsyncMock(return_value=FAKE_AUTH))
+
+
+# ── milestones list ────────────────────────────────────────────────────────────
+
+MILESTONE_DATA = [
+    {
+        "_id": "m1",
+        "label": "Sprint 1",
+        "status": 0,
+        "targetDate": None,
+        "comments": 0,
+        "space": "p1",
+        "createdBy": "",
+        "createdOn": 0,
+        "modifiedBy": "",
+        "modifiedOn": 0,
+    }
+]
+
+
+def test_milestones_list():
+    find_mock = AsyncMock(return_value=MILESTONE_DATA)
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["milestones", "list"])
+    assert result.exit_code == 0, result.output
+    assert "Sprint 1" in result.output
+
+
+def test_milestones_list_shows_status():
+    find_mock = AsyncMock(return_value=MILESTONE_DATA)
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["milestones", "list"])
+    assert result.exit_code == 0, result.output
+    assert "planned" in result.output.lower()
+
+
+def test_milestones_list_empty():
+    find_mock = AsyncMock(return_value=[])
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["milestones", "list"])
+    assert result.exit_code == 0
+
+
+def test_milestones_list_json_mode():
+    import json as json_mod
+
+    find_mock = AsyncMock(return_value=MILESTONE_DATA)
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["--json", "milestones", "list"])
+    assert result.exit_code == 0, result.output
+    data = json_mod.loads(result.output)
+    assert data["ok"] is True
+    assert isinstance(data["data"], list)
+
+
+def test_milestones_list_with_project_filter():
+    project_data = [{"_id": "p1", "identifier": "TP", "name": "Test Project"}]
+    find_mock = AsyncMock(side_effect=[project_data, MILESTONE_DATA])
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["milestones", "list", "--project", "TP"])
+    assert result.exit_code == 0, result.output
+    assert "Sprint 1" in result.output
+
+
+# ── templates list ─────────────────────────────────────────────────────────────
+
+TEMPLATE_DATA = [
+    {
+        "_id": "tmpl1",
+        "title": "Bug Report",
+        "description": "",
+        "assignee": None,
+        "component": None,
+        "milestone": None,
+        "priority": 1,
+        "estimation": 0,
+        "children": [],
+        "comments": 0,
+        "attachments": 0,
+        "labels": 0,
+        "kind": "",
+        "relations": [],
+        "space": "p1",
+    }
+]
+
+
+def test_templates_list():
+    find_mock = AsyncMock(return_value=TEMPLATE_DATA)
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["templates", "list"])
+    assert result.exit_code == 0, result.output
+    assert "Bug Report" in result.output
+
+
+def test_templates_list_shows_priority():
+    find_mock = AsyncMock(return_value=TEMPLATE_DATA)
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["templates", "list"])
+    assert result.exit_code == 0, result.output
+    assert "Urgent" in result.output
+
+
+def test_templates_list_empty():
+    find_mock = AsyncMock(return_value=[])
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["templates", "list"])
+    assert result.exit_code == 0
+
+
+def test_templates_list_json_mode():
+    import json as json_mod
+
+    find_mock = AsyncMock(return_value=TEMPLATE_DATA)
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["--json", "templates", "list"])
+    assert result.exit_code == 0, result.output
+    data = json_mod.loads(result.output)
+    assert data["ok"] is True
+    assert len(data["data"]) == 1
+    assert data["data"][0]["title"] == "Bug Report"
+
+
+def test_templates_list_multiple():
+    template_data = [
+        {
+            "_id": "t1",
+            "title": "Template A",
+            "description": "",
+            "priority": 0,
+            "kind": "",
+            "space": "p1",
+            "assignee": None,
+            "component": None,
+            "milestone": None,
+            "estimation": 0,
+            "children": [],
+            "comments": 0,
+            "attachments": 0,
+            "labels": 0,
+            "relations": [],
+        },
+        {
+            "_id": "t2",
+            "title": "Template B",
+            "description": "",
+            "priority": 2,
+            "kind": "",
+            "space": "p1",
+            "assignee": None,
+            "component": None,
+            "milestone": None,
+            "estimation": 0,
+            "children": [],
+            "comments": 0,
+            "attachments": 0,
+            "labels": 0,
+            "relations": [],
+        },
+    ]
+    find_mock = AsyncMock(return_value=template_data)
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["templates", "list"])
+    assert result.exit_code == 0, result.output
+    assert "Template A" in result.output
+    assert "Template B" in result.output
+
+
+def test_templates_list_with_project_filter():
+    project_data = [{"_id": "p1", "identifier": "TP", "name": "Test Project"}]
+    find_mock = AsyncMock(side_effect=[project_data, TEMPLATE_DATA])
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["templates", "list", "--project", "TP"])
+    assert result.exit_code == 0, result.output
+    assert "Bug Report" in result.output
+
+
+def test_milestones_list_multiple_statuses():
+    """Milestones with different statuses should all appear."""
+    milestone_data = [
+        {
+            "_id": "m1",
+            "label": "Sprint 1",
+            "status": 0,
+            "targetDate": None,
+            "comments": 0,
+            "space": "p1",
+            "createdBy": "",
+            "createdOn": 0,
+            "modifiedBy": "",
+            "modifiedOn": 0,
+        },
+        {
+            "_id": "m2",
+            "label": "Sprint 2",
+            "status": 2,
+            "targetDate": 1700000000000,
+            "comments": 0,
+            "space": "p1",
+            "createdBy": "",
+            "createdOn": 0,
+            "modifiedBy": "",
+            "modifiedOn": 0,
+        },
+    ]
+    find_mock = AsyncMock(return_value=milestone_data)
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["milestones", "list"])
+    assert result.exit_code == 0, result.output
+    assert "Sprint 1" in result.output
+    assert "Sprint 2" in result.output
+    assert "completed" in result.output.lower()


### PR DESCRIPTION
## Summary

First set of commands — covers the most common Huly entities.

- `huly issues list/get/create/update` — full CRUD with `--project`, `--status`, `--assignee` (fuzzy match), `--priority` filters; create resolves project identifier and person name automatically
- `huly issues describe ROA-1` — reads descriptions rendered as markdown; `--set` and `--set-file` write back via Collaborator RPC using the `source` field discovery (required for `updateContent` on v0.6.493)
- `huly projects list/get` — project details with member counts
- `huly members list` — joins Person + PersonAccount to show display names alongside emails
- `huly labels list` — deduplicates TagReference entries and shows per-label usage count
- All commands support `--json` mode for programmatic consumption

## Context

- Issue descriptions are blob refs, not inline text — the `describe` command handles the Collaborator RPC round-trip transparently
- Person names are stored as `"LastName,FirstName"` — all display and fuzzy matching normalizes to `"FirstName LastName"` format
- `issues create --description` creates the issue first via `TxCreateDoc`, re-fetches to get the blob ref, then writes content via `set_description`