### PR TITLE
feat: CRUD for documents, components, milestones, and templates

### DIFF
--- a/src/huly_cli/client.py
+++ b/src/huly_cli/client.py
@@ -70,9 +70,16 @@ class HulyClient:
 
     # ── Collaborator RPC ──────────────────────────────────────────────────────
 
-    async def get_description(self, issue_id: str, blob_ref: str) -> str | None:
-        """Fetch issue description ProseMirror JSON via Collaborator RPC."""
-        doc_id = self._build_doc_id(issue_id)
+    async def get_content(
+        self, class_id: str, object_id: str, field: str, blob_ref: str
+    ) -> str | None:
+        """Fetch entity content ProseMirror JSON via Collaborator RPC.
+
+        Works for any entity class and field, e.g.:
+          - class_id="tracker:class:Issue", field="description"
+          - class_id="document:class:Document", field="content"
+        """
+        doc_id = self._build_doc_id(class_id, object_id, field)
         url = f"{self._config.url}/_collaborator/rpc/{doc_id}"
         try:
             async with httpx.AsyncClient(timeout=15.0) as http:
@@ -88,7 +95,7 @@ class HulyClient:
                     print_warning(f"getContent returned HTTP {resp.status_code}: {resp.text[:200]}")
                     return None
                 data = resp.json()
-                content = data.get("content", {}).get("description")
+                content = data.get("content", {}).get(field)
                 if content is None:
                     return None
                 if isinstance(content, (dict, list)):
@@ -98,9 +105,14 @@ class HulyClient:
             print_warning(f"getContent error: {e}")
             return None
 
-    async def set_description(self, issue_id: str, blob_ref: str, markup_json: str) -> bool:
-        """Update issue description via Collaborator RPC."""
-        doc_id = self._build_doc_id(issue_id)
+    async def set_content(
+        self, class_id: str, object_id: str, field: str, blob_ref: str, markup_json: str
+    ) -> bool:
+        """Update entity content via Collaborator RPC.
+
+        Works for any entity class and field.
+        """
+        doc_id = self._build_doc_id(class_id, object_id, field)
         url = f"{self._config.url}/_collaborator/rpc/{doc_id}"
         try:
             async with httpx.AsyncClient(timeout=15.0) as http:
@@ -114,7 +126,7 @@ class HulyClient:
                         "method": "updateContent",
                         "payload": {
                             "source": blob_ref,
-                            "content": {"description": json_mod.loads(markup_json)},
+                            "content": {field: json_mod.loads(markup_json)},
                         },
                     },
                 )
@@ -128,9 +140,25 @@ class HulyClient:
             print_warning(f"updateContent error: {e}")
             return False
 
-    def _build_doc_id(self, issue_id: str) -> str:
-        """URL-encode the collaborator document ID for an issue description."""
-        raw = f"{self._auth.workspace_uuid}|tracker:class:Issue|{issue_id}|description"
+    async def get_description(self, issue_id: str, blob_ref: str) -> str | None:
+        """Fetch issue description ProseMirror JSON via Collaborator RPC.
+
+        Thin wrapper around get_content for tracker:class:Issue / description.
+        """
+        return await self.get_content("tracker:class:Issue", issue_id, "description", blob_ref)
+
+    async def set_description(self, issue_id: str, blob_ref: str, markup_json: str) -> bool:
+        """Update issue description via Collaborator RPC.
+
+        Thin wrapper around set_content for tracker:class:Issue / description.
+        """
+        return await self.set_content(
+            "tracker:class:Issue", issue_id, "description", blob_ref, markup_json
+        )
+
+    def _build_doc_id(self, class_id: str, object_id: str, field: str) -> str:
+        """URL-encode the collaborator document ID for any entity class and field."""
+        raw = f"{self._auth.workspace_uuid}|{class_id}|{object_id}|{field}"
         return urllib.parse.quote(raw, safe="")
 
     # ── Response handling ─────────────────────────────────────────────────────

--- a/src/huly_cli/commands/components.py
+++ b/src/huly_cli/commands/components.py
@@ -1,0 +1,322 @@
+"""Components commands: list, get, create, update."""
+
+from __future__ import annotations
+
+import asyncio
+import secrets
+import time
+from typing import Annotated, Any
+
+import typer
+
+from huly_cli.auth import ensure_auth
+from huly_cli.client import HulyClient
+from huly_cli.config import load_config
+from huly_cli.errors import AuthError, HulyError, NotFoundError
+from huly_cli.models import Component
+from huly_cli.output import print_error, print_item, print_list, print_success, print_warning
+
+app = typer.Typer(help="Manage Huly components.", no_args_is_help=True)
+
+
+# ── Shared helpers ────────────────────────────────────────────────────────────
+
+
+async def _resolve_project_by_identifier(client: HulyClient, identifier: str) -> tuple[str, str]:
+    """Return (project_id, project_name) for the given identifier."""
+    projects = await client.find_all(
+        "tracker:class:Project",
+        query={"identifier": identifier.upper()},
+        options={"limit": 1},
+    )
+    if not projects:
+        raise NotFoundError(f"Project '{identifier}' not found.")
+    proj = projects[0]
+    return proj["_id"], proj.get("name", identifier)
+
+
+async def _fetch_person_map(client: HulyClient) -> dict[str, str]:
+    """Return map of person_id → display_name."""
+    raw = await client.find_all("contact:class:Person", options={"limit": 500})
+    result: dict[str, str] = {}
+    for p in raw:
+        name: str = p.get("name", "")
+        parts = name.split(",", 1)
+        display = f"{parts[1].strip()} {parts[0].strip()}" if len(parts) == 2 else name
+        result[p["_id"]] = display
+    return result
+
+
+async def _resolve_person_by_name(client: HulyClient, name: str) -> str:
+    """Fuzzy-match a person by name and return their ID."""
+    persons = await client.find_all("contact:class:Person", options={"limit": 500})
+    query_lower = name.lower()
+    for p in persons:
+        raw_name: str = p.get("name", "")
+        parts = raw_name.split(",", 1)
+        display = f"{parts[1].strip()} {parts[0].strip()}" if len(parts) == 2 else raw_name
+        if query_lower in display.lower() or query_lower in raw_name.lower():
+            return p["_id"]
+    raise NotFoundError(f"Person '{name}' not found.")
+
+
+def _truncate(text: str, max_len: int = 60) -> str:
+    return text if len(text) <= max_len else text[: max_len - 3] + "..."
+
+
+def _component_to_row(comp: Component, person_map: dict[str, str]) -> dict[str, Any]:
+    lead_name = person_map.get(comp.lead, comp.lead) if comp.lead else ""
+    return {
+        "label": comp.label,
+        "description": _truncate(comp.description),
+        "lead": lead_name,
+        "id": comp.id,
+    }
+
+
+def _component_to_detail(comp: Component, person_map: dict[str, str]) -> dict[str, Any]:
+    lead_name = person_map.get(comp.lead, comp.lead) if comp.lead else ""
+    return {
+        "label": comp.label,
+        "id": comp.id,
+        "space": comp.space,
+        "description": comp.description,
+        "lead": lead_name,
+        "lead_id": comp.lead,
+        "created_by": comp.created_by,
+        "modified_by": comp.modified_by,
+    }
+
+
+# ── Commands ──────────────────────────────────────────────────────────────────
+
+
+@app.command("list")
+def components_list(
+    ctx: typer.Context,
+    project: Annotated[
+        str | None,
+        typer.Option("--project", "-p", help="Filter by project identifier (e.g. ROA)."),
+    ] = None,
+    limit: Annotated[
+        int,
+        typer.Option("--limit", "-n", help="Maximum number of components to return."),
+    ] = 50,
+) -> None:
+    """List components, with optional project filter."""
+    overrides: dict = ctx.obj or {}
+    config = load_config(
+        url_override=overrides.get("url"),
+        workspace_override=overrides.get("workspace"),
+    )
+
+    async def _run() -> list[dict[str, Any]]:
+        auth = await ensure_auth(config)
+        async with HulyClient(config, auth) as client:
+            query: dict[str, Any] = {}
+            if project:
+                project_id, _ = await _resolve_project_by_identifier(client, project)
+                query["space"] = project_id
+
+            raw = await client.find_all(
+                "tracker:class:Component",
+                query=query,
+                options={"limit": limit},
+            )
+            components = [Component.model_validate(doc) for doc in raw]
+            person_map = await _fetch_person_map(client)
+
+        return [_component_to_row(c, person_map) for c in components]
+
+    try:
+        rows = asyncio.run(_run())
+    except AuthError as e:
+        print_error(e.message, hint="Run 'huly auth login' to authenticate.")
+        raise typer.Exit(2) from e
+    except HulyError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+
+    print_list(rows, columns=["label", "description", "lead", "id"], title="Components")
+
+
+@app.command("get")
+def components_get(
+    ctx: typer.Context,
+    component_id: str = typer.Argument(..., help="Component internal ID."),
+) -> None:
+    """Get details of a component."""
+    overrides: dict = ctx.obj or {}
+    config = load_config(
+        url_override=overrides.get("url"),
+        workspace_override=overrides.get("workspace"),
+    )
+
+    async def _run() -> dict[str, Any]:
+        auth = await ensure_auth(config)
+        async with HulyClient(config, auth) as client:
+            raw = await client.find_all(
+                "tracker:class:Component",
+                query={"_id": component_id},
+                options={"limit": 1},
+            )
+            if not raw:
+                raise NotFoundError(f"Component '{component_id}' not found.")
+            comp = Component.model_validate(raw[0])
+            person_map = await _fetch_person_map(client)
+        return _component_to_detail(comp, person_map)
+
+    try:
+        data = asyncio.run(_run())
+    except NotFoundError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+    except AuthError as e:
+        print_error(e.message, hint="Run 'huly auth login' to authenticate.")
+        raise typer.Exit(2) from e
+    except HulyError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+
+    print_item(data, title=f"Component: {data.get('label', component_id)}")
+
+
+@app.command("create")
+def components_create(
+    ctx: typer.Context,
+    label: Annotated[str, typer.Option("--label", help="Component label.")] = ...,
+    project: Annotated[
+        str, typer.Option("--project", help='Project identifier (e.g. "ROA").')
+    ] = ...,
+    lead: Annotated[
+        str | None, typer.Option("--lead", help="Lead person name (fuzzy match).")
+    ] = None,
+    description: Annotated[
+        str | None, typer.Option("--description", help="Component description.")
+    ] = None,
+) -> None:
+    """Create a new component."""
+    overrides: dict = ctx.obj or {}
+    config = load_config(
+        url_override=overrides.get("url"),
+        workspace_override=overrides.get("workspace"),
+    )
+
+    async def _run() -> str:
+        auth = await ensure_auth(config)
+        async with HulyClient(config, auth) as client:
+            project_id, _ = await _resolve_project_by_identifier(client, project)
+
+            lead_id: str | None = None
+            if lead:
+                lead_id = await _resolve_person_by_name(client, lead)
+
+            new_id = secrets.token_hex(12)
+
+            transaction = {
+                "_class": "core:class:TxCreateDoc",
+                "objectClass": "tracker:class:Component",
+                "objectSpace": project_id,
+                "objectId": new_id,
+                "attributes": {
+                    "label": label,
+                    "description": description or "",
+                    "lead": lead_id,
+                },
+                "modifiedBy": auth.account_id,
+                "modifiedOn": int(time.time() * 1000),
+            }
+
+            await client.tx(transaction)
+        return new_id
+
+    try:
+        new_id = asyncio.run(_run())
+        print_success(f"Component created in project '{project}' (id: {new_id})")
+    except NotFoundError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+    except AuthError as e:
+        print_error(e.message, hint="Run 'huly auth login' to authenticate.")
+        raise typer.Exit(2) from e
+    except HulyError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+
+
+@app.command("update")
+def components_update(
+    ctx: typer.Context,
+    component_id: str = typer.Argument(..., help="Component internal ID."),
+    label: Annotated[str | None, typer.Option("--label", help="New component label.")] = None,
+    lead: Annotated[
+        str | None, typer.Option("--lead", help='New lead person name. Use "" to unassign.')
+    ] = None,
+    description: Annotated[
+        str | None, typer.Option("--description", help="New description.")
+    ] = None,
+) -> None:
+    """Update an existing component."""
+    overrides: dict = ctx.obj or {}
+    config = load_config(
+        url_override=overrides.get("url"),
+        workspace_override=overrides.get("workspace"),
+    )
+
+    async def _run() -> None:
+        auth = await ensure_auth(config)
+        async with HulyClient(config, auth) as client:
+            raw = await client.find_all(
+                "tracker:class:Component",
+                query={"_id": component_id},
+                options={"limit": 1},
+            )
+            if not raw:
+                raise NotFoundError(f"Component '{component_id}' not found.")
+            comp = Component.model_validate(raw[0])
+
+            operations: dict = {}
+
+            if label is not None:
+                operations["label"] = label
+
+            if description is not None:
+                operations["description"] = description
+
+            if lead is not None:
+                if lead == "":
+                    operations["lead"] = None
+                else:
+                    lead_id = await _resolve_person_by_name(client, lead)
+                    operations["lead"] = lead_id
+
+            if not operations:
+                print_warning(
+                    "No fields to update — provide at least one of --label, --lead, --description."
+                )
+                return
+
+            transaction = {
+                "_class": "core:class:TxUpdateDoc",
+                "objectClass": "tracker:class:Component",
+                "objectSpace": comp.space,
+                "objectId": comp.id,
+                "operations": operations,
+                "modifiedBy": auth.account_id,
+                "modifiedOn": int(time.time() * 1000),
+            }
+
+            await client.tx(transaction)
+
+    try:
+        asyncio.run(_run())
+        print_success(f"Component {component_id} updated.")
+    except NotFoundError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+    except AuthError as e:
+        print_error(e.message, hint="Run 'huly auth login' to authenticate.")
+        raise typer.Exit(2) from e
+    except HulyError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e

--- a/src/huly_cli/commands/documents.py
+++ b/src/huly_cli/commands/documents.py
@@ -1,0 +1,442 @@
+"""Documents commands: list, get, create, update, describe."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import secrets
+import time
+from typing import Annotated, Any
+
+import typer
+
+from huly_cli.auth import ensure_auth
+from huly_cli.client import HulyClient
+from huly_cli.config import load_config
+from huly_cli.errors import AuthError, HulyError, NotFoundError
+from huly_cli.models import Document
+from huly_cli.output import (
+    console,
+    is_json_mode,
+    print_error,
+    print_item,
+    print_list,
+    print_success,
+    print_warning,
+)
+
+app = typer.Typer(help="Manage Huly documents.", no_args_is_help=True)
+
+
+# ── Shared helpers ────────────────────────────────────────────────────────────
+
+
+async def _fetch_teamspace_map(client: HulyClient) -> dict[str, str]:
+    """Return map of teamspace_id → name."""
+    raw = await client.find_all("document:class:Teamspace", options={"limit": 200})
+    return {ts["_id"]: ts.get("name", ts["_id"]) for ts in raw}
+
+
+async def _resolve_teamspace_by_name(client: HulyClient, name: str) -> str:
+    """Resolve a teamspace name to its ID. Raises NotFoundError if not found."""
+    raw = await client.find_all("document:class:Teamspace", options={"limit": 200})
+    name_lower = name.lower()
+    for ts in raw:
+        if ts.get("name", "").lower() == name_lower:
+            return ts["_id"]
+    raise NotFoundError(f"Teamspace '{name}' not found.")
+
+
+def _doc_to_row(doc: Document, space_map: dict[str, str]) -> dict[str, Any]:
+    space_name = space_map.get(doc.space, doc.space)
+    parent = "" if doc.parent in ("document:ids:NoParent", "") else doc.parent
+    return {
+        "title": doc.title,
+        "space": space_name,
+        "parent": parent,
+        "id": doc.id,
+    }
+
+
+def _doc_to_detail(doc: Document, space_map: dict[str, str]) -> dict[str, Any]:
+    space_name = space_map.get(doc.space, doc.space)
+    parent = "" if doc.parent in ("document:ids:NoParent", "") else doc.parent
+    return {
+        "title": doc.title,
+        "id": doc.id,
+        "space": space_name,
+        "space_id": doc.space,
+        "parent": parent,
+        "content_ref": doc.content,
+        "attachments": doc.attachments,
+        "labels": doc.labels,
+        "comments": doc.comments,
+        "rank": doc.rank,
+        "created_by": doc.created_by,
+        "created_on": doc.created_on,
+        "modified_by": doc.modified_by,
+        "modified_on": doc.modified_on,
+    }
+
+
+# ── Commands ──────────────────────────────────────────────────────────────────
+
+
+@app.command("list")
+def docs_list(
+    ctx: typer.Context,
+    space: Annotated[
+        str | None,
+        typer.Option("--space", "-s", help="Filter by teamspace name."),
+    ] = None,
+    limit: Annotated[
+        int,
+        typer.Option("--limit", "-n", help="Maximum number of documents to return."),
+    ] = 50,
+) -> None:
+    """List documents, with optional teamspace filter."""
+    overrides: dict = ctx.obj or {}
+    config = load_config(
+        url_override=overrides.get("url"),
+        workspace_override=overrides.get("workspace"),
+    )
+
+    async def _run() -> list[dict[str, Any]]:
+        auth = await ensure_auth(config)
+        async with HulyClient(config, auth) as client:
+            space_map = await _fetch_teamspace_map(client)
+
+            query: dict[str, Any] = {}
+            if space:
+                space_id = await _resolve_teamspace_by_name(client, space)
+                query["space"] = space_id
+
+            raw = await client.find_all(
+                "document:class:Document",
+                query=query,
+                options={"limit": limit},
+            )
+            docs = [Document.model_validate(doc) for doc in raw]
+
+        return [_doc_to_row(d, space_map) for d in docs]
+
+    try:
+        rows = asyncio.run(_run())
+    except AuthError as e:
+        print_error(e.message, hint="Run 'huly auth login' to authenticate.")
+        raise typer.Exit(2) from e
+    except HulyError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+
+    print_list(rows, columns=["title", "space", "parent", "id"], title="Documents")
+
+
+@app.command("get")
+def docs_get(
+    ctx: typer.Context,
+    doc_id: str = typer.Argument(..., help="Document internal ID."),
+) -> None:
+    """Get details of a document."""
+    overrides: dict = ctx.obj or {}
+    config = load_config(
+        url_override=overrides.get("url"),
+        workspace_override=overrides.get("workspace"),
+    )
+
+    async def _run() -> dict[str, Any]:
+        auth = await ensure_auth(config)
+        async with HulyClient(config, auth) as client:
+            raw = await client.find_all(
+                "document:class:Document",
+                query={"_id": doc_id},
+                options={"limit": 1},
+            )
+            if not raw:
+                raise NotFoundError(f"Document '{doc_id}' not found.")
+            doc = Document.model_validate(raw[0])
+            space_map = await _fetch_teamspace_map(client)
+        return _doc_to_detail(doc, space_map)
+
+    try:
+        data = asyncio.run(_run())
+    except NotFoundError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+    except AuthError as e:
+        print_error(e.message, hint="Run 'huly auth login' to authenticate.")
+        raise typer.Exit(2) from e
+    except HulyError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+
+    print_item(data, title=f"Document: {data.get('title', doc_id)}")
+
+
+@app.command("create")
+def docs_create(
+    ctx: typer.Context,
+    title: Annotated[str, typer.Option("--title", help="Document title.")] = ...,
+    space: Annotated[str, typer.Option("--space", help="Teamspace name.")] = ...,
+    parent: Annotated[str | None, typer.Option("--parent", help="Parent document ID.")] = None,
+) -> None:
+    """Create a new document."""
+    overrides: dict = ctx.obj or {}
+    config = load_config(
+        url_override=overrides.get("url"),
+        workspace_override=overrides.get("workspace"),
+    )
+
+    async def _run() -> str:
+        auth = await ensure_auth(config)
+        async with HulyClient(config, auth) as client:
+            space_id = await _resolve_teamspace_by_name(client, space)
+
+            parent_id = parent if parent else "document:ids:NoParent"
+            new_id = secrets.token_hex(12)
+
+            transaction = {
+                "_class": "core:class:TxCreateDoc",
+                "objectClass": "document:class:Document",
+                "objectSpace": space_id,
+                "objectId": new_id,
+                "attributes": {
+                    "title": title,
+                    "content": "",
+                    "parent": parent_id,
+                    "attachments": 0,
+                    "embeddings": 0,
+                    "labels": 0,
+                    "comments": 0,
+                    "references": 0,
+                    "rank": "",
+                },
+                "modifiedBy": auth.account_id,
+                "modifiedOn": int(time.time() * 1000),
+            }
+
+            await client.tx(transaction)
+        return new_id
+
+    try:
+        new_id = asyncio.run(_run())
+        print_success(f"Document created in teamspace '{space}' (id: {new_id})")
+    except NotFoundError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+    except AuthError as e:
+        print_error(e.message, hint="Run 'huly auth login' to authenticate.")
+        raise typer.Exit(2) from e
+    except HulyError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+
+
+@app.command("update")
+def docs_update(
+    ctx: typer.Context,
+    doc_id: str = typer.Argument(..., help="Document internal ID."),
+    title: Annotated[str | None, typer.Option("--title", help="New document title.")] = None,
+) -> None:
+    """Update an existing document."""
+    overrides: dict = ctx.obj or {}
+    config = load_config(
+        url_override=overrides.get("url"),
+        workspace_override=overrides.get("workspace"),
+    )
+
+    async def _run() -> None:
+        auth = await ensure_auth(config)
+        async with HulyClient(config, auth) as client:
+            raw = await client.find_all(
+                "document:class:Document",
+                query={"_id": doc_id},
+                options={"limit": 1},
+            )
+            if not raw:
+                raise NotFoundError(f"Document '{doc_id}' not found.")
+            doc = Document.model_validate(raw[0])
+
+            operations: dict = {}
+            if title is not None:
+                operations["title"] = title
+
+            if not operations:
+                print_warning("No fields to update — provide at least one of --title.")
+                return
+
+            transaction = {
+                "_class": "core:class:TxUpdateDoc",
+                "objectClass": "document:class:Document",
+                "objectSpace": doc.space,
+                "objectId": doc.id,
+                "operations": operations,
+                "modifiedBy": auth.account_id,
+                "modifiedOn": int(time.time() * 1000),
+            }
+
+            await client.tx(transaction)
+
+    try:
+        asyncio.run(_run())
+        print_success(f"Document {doc_id} updated.")
+    except NotFoundError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+    except AuthError as e:
+        print_error(e.message, hint="Run 'huly auth login' to authenticate.")
+        raise typer.Exit(2) from e
+    except HulyError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+
+
+@app.command("describe")
+def docs_describe(
+    ctx: typer.Context,
+    doc_id: str = typer.Argument(..., help="Document internal ID."),
+    raw: Annotated[
+        bool,
+        typer.Option("--raw", help="Show raw ProseMirror JSON instead of rendered markdown."),
+    ] = False,
+    set_text: Annotated[
+        str | None,
+        typer.Option("--set", help="Set content from markdown string."),
+    ] = None,
+    set_file: Annotated[
+        str | None,
+        typer.Option("--set-file", help="Set content from a markdown file path."),
+    ] = None,
+) -> None:
+    """Read or update the content of a document.
+
+    By default, reads and displays the content. Use --set or --set-file to write.
+    """
+    if set_text and set_file:
+        print_error("Use either --set or --set-file, not both.")
+        raise typer.Exit(1)
+
+    overrides: dict = ctx.obj or {}
+    config = load_config(
+        url_override=overrides.get("url"),
+        workspace_override=overrides.get("workspace"),
+    )
+
+    # ── Write path ────────────────────────────────────────────────────────
+    if set_text is not None or set_file is not None:
+        markdown_content = set_text
+        if set_file is not None:
+            import pathlib
+
+            p = pathlib.Path(set_file)
+            if not p.exists():
+                print_error(f"File not found: {set_file}")
+                raise typer.Exit(1)
+            markdown_content = p.read_text(encoding="utf-8")
+
+        async def _write() -> str:
+            from huly_cli.markup import markdown_to_prosemirror
+
+            auth = await ensure_auth(config)
+            async with HulyClient(config, auth) as client:
+                raw_docs = await client.find_all(
+                    "document:class:Document",
+                    query={"_id": doc_id},
+                    options={"limit": 1},
+                )
+                if not raw_docs:
+                    raise NotFoundError(f"Document '{doc_id}' not found.")
+                doc = Document.model_validate(raw_docs[0])
+                if not doc.content:
+                    raise HulyError(
+                        f"Document '{doc_id}' has no content blob ref. "
+                        "Cannot update content that was never created."
+                    )
+                markup = markdown_to_prosemirror(markdown_content or "")
+                ok = await client.set_content(
+                    "document:class:Document", doc.id, "content", doc.content, markup
+                )
+                if not ok:
+                    raise HulyError("Failed to update content via Collaborator RPC.")
+            return doc.title or doc_id
+
+        try:
+            title_label = asyncio.run(_write())
+        except NotFoundError as e:
+            print_error(e.message)
+            raise typer.Exit(1) from e
+        except AuthError as e:
+            print_error(e.message, hint="Run 'huly auth login' to authenticate.")
+            raise typer.Exit(2) from e
+        except HulyError as e:
+            print_error(e.message)
+            raise typer.Exit(1) from e
+
+        print_success(f"Content updated for '{title_label}'.")
+        return
+
+    # ── Read path ─────────────────────────────────────────────────────────
+    async def _run() -> tuple[str, str | None]:
+        auth = await ensure_auth(config)
+        async with HulyClient(config, auth) as client:
+            raw_docs = await client.find_all(
+                "document:class:Document",
+                query={"_id": doc_id},
+                options={"limit": 1},
+            )
+            if not raw_docs:
+                raise NotFoundError(f"Document '{doc_id}' not found.")
+            doc = Document.model_validate(raw_docs[0])
+            if not doc.content:
+                return doc.title or doc_id, None
+            content = await client.get_content(
+                "document:class:Document", doc.id, "content", doc.content
+            )
+        return doc.title or doc_id, content
+
+    try:
+        title_label, content = asyncio.run(_run())
+    except NotFoundError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+    except AuthError as e:
+        print_error(e.message, hint="Run 'huly auth login' to authenticate.")
+        raise typer.Exit(2) from e
+    except HulyError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+
+    if content is None:
+        print_error(f"No content available for document '{title_label}'.")
+        raise typer.Exit(1)
+
+    if is_json_mode():
+        if raw:
+            print(json.dumps({"ok": True, "id": doc_id, "content_raw": content}))
+        else:
+            from huly_cli.markup import prosemirror_to_markdown
+
+            md = prosemirror_to_markdown(content)
+            print(json.dumps({"ok": True, "id": doc_id, "content": md}))
+        return
+
+    if raw:
+        try:
+            parsed = json.loads(content)
+            console.print_json(json.dumps(parsed, indent=2))
+        except (json.JSONDecodeError, TypeError):
+            console.print(content)
+    else:
+        from rich.markdown import Markdown
+        from rich.panel import Panel
+
+        from huly_cli.markup import prosemirror_to_markdown
+
+        md_text = prosemirror_to_markdown(content)
+        if md_text.strip():
+            console.print(Panel(Markdown(md_text), title=f"Content: {title_label}"))
+        else:
+            from huly_cli.markup import prosemirror_to_text
+
+            plain = prosemirror_to_text(content)
+            console.print(Panel(plain or "(empty content)", title=f"Content: {title_label}"))

--- a/src/huly_cli/commands/milestones.py
+++ b/src/huly_cli/commands/milestones.py
@@ -1,0 +1,332 @@
+"""Milestones commands: list, get, create, update."""
+
+from __future__ import annotations
+
+import asyncio
+import datetime
+import secrets
+import time
+from typing import Annotated, Any
+
+import typer
+
+from huly_cli.auth import ensure_auth
+from huly_cli.client import HulyClient
+from huly_cli.config import load_config
+from huly_cli.errors import AuthError, HulyError, NotFoundError
+from huly_cli.models import MILESTONE_STATUS_FROM_NAME, Milestone
+from huly_cli.output import print_error, print_item, print_list, print_success, print_warning
+
+app = typer.Typer(help="Manage Huly milestones.", no_args_is_help=True)
+
+
+# ── Shared helpers ────────────────────────────────────────────────────────────
+
+
+async def _resolve_project_by_identifier(client: HulyClient, identifier: str) -> str:
+    """Return project_id for the given identifier."""
+    projects = await client.find_all(
+        "tracker:class:Project",
+        query={"identifier": identifier.upper()},
+        options={"limit": 1},
+    )
+    if not projects:
+        raise NotFoundError(f"Project '{identifier}' not found.")
+    return projects[0]["_id"]
+
+
+def _parse_date_ms(date_str: str) -> int:
+    """Parse a YYYY-MM-DD date string and return a UTC millisecond timestamp."""
+    dt = datetime.datetime.strptime(date_str, "%Y-%m-%d").replace(tzinfo=datetime.UTC)
+    return int(dt.timestamp() * 1000)
+
+
+def _format_date(ms: int | None) -> str:
+    """Format a millisecond UTC timestamp as YYYY-MM-DD, or '' if None."""
+    if ms is None:
+        return ""
+    dt = datetime.datetime.fromtimestamp(ms / 1000, tz=datetime.UTC)
+    return dt.strftime("%Y-%m-%d")
+
+
+def _milestone_to_row(m: Milestone) -> dict[str, Any]:
+    return {
+        "label": m.label,
+        "status": m.status_name,
+        "target_date": _format_date(m.target_date),
+        "id": m.id,
+    }
+
+
+def _milestone_to_detail(m: Milestone) -> dict[str, Any]:
+    return {
+        "label": m.label,
+        "id": m.id,
+        "space": m.space,
+        "status": m.status_name,
+        "status_int": m.status,
+        "target_date": _format_date(m.target_date),
+        "target_date_ms": m.target_date,
+        "comments": m.comments,
+        "created_by": m.created_by,
+        "modified_by": m.modified_by,
+    }
+
+
+def _resolve_status(status_name: str) -> int:
+    key = status_name.lower().replace(" ", "-")
+    val = MILESTONE_STATUS_FROM_NAME.get(key)
+    if val is None:
+        valid = ", ".join(MILESTONE_STATUS_FROM_NAME.keys())
+        raise HulyError(f"Unknown milestone status '{status_name}'. Valid values: {valid}")
+    return val
+
+
+# ── Commands ──────────────────────────────────────────────────────────────────
+
+
+@app.command("list")
+def milestones_list(
+    ctx: typer.Context,
+    project: Annotated[
+        str | None,
+        typer.Option("--project", "-p", help="Filter by project identifier (e.g. ROA)."),
+    ] = None,
+    status: Annotated[
+        str | None,
+        typer.Option("--status", "-s", help="Filter by status: planned, in-progress, completed."),
+    ] = None,
+    limit: Annotated[
+        int,
+        typer.Option("--limit", "-n", help="Maximum number of milestones to return."),
+    ] = 50,
+) -> None:
+    """List milestones, with optional project and status filters."""
+    overrides: dict = ctx.obj or {}
+    config = load_config(
+        url_override=overrides.get("url"),
+        workspace_override=overrides.get("workspace"),
+    )
+
+    async def _run() -> list[dict[str, Any]]:
+        auth = await ensure_auth(config)
+        async with HulyClient(config, auth) as client:
+            query: dict[str, Any] = {}
+
+            if status:
+                status_int = _resolve_status(status)
+                query["status"] = status_int
+
+            if project:
+                project_id = await _resolve_project_by_identifier(client, project)
+                query["space"] = project_id
+
+            raw = await client.find_all(
+                "tracker:class:Milestone",
+                query=query,
+                options={"limit": limit},
+            )
+            milestones = [Milestone.model_validate(doc) for doc in raw]
+
+        return [_milestone_to_row(m) for m in milestones]
+
+    try:
+        rows = asyncio.run(_run())
+    except AuthError as e:
+        print_error(e.message, hint="Run 'huly auth login' to authenticate.")
+        raise typer.Exit(2) from e
+    except HulyError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+
+    print_list(rows, columns=["label", "status", "target_date", "id"], title="Milestones")
+
+
+@app.command("get")
+def milestones_get(
+    ctx: typer.Context,
+    milestone_id: str = typer.Argument(..., help="Milestone internal ID."),
+) -> None:
+    """Get details of a milestone."""
+    overrides: dict = ctx.obj or {}
+    config = load_config(
+        url_override=overrides.get("url"),
+        workspace_override=overrides.get("workspace"),
+    )
+
+    async def _run() -> dict[str, Any]:
+        auth = await ensure_auth(config)
+        async with HulyClient(config, auth) as client:
+            raw = await client.find_all(
+                "tracker:class:Milestone",
+                query={"_id": milestone_id},
+                options={"limit": 1},
+            )
+            if not raw:
+                raise NotFoundError(f"Milestone '{milestone_id}' not found.")
+            milestone = Milestone.model_validate(raw[0])
+        return _milestone_to_detail(milestone)
+
+    try:
+        data = asyncio.run(_run())
+    except NotFoundError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+    except AuthError as e:
+        print_error(e.message, hint="Run 'huly auth login' to authenticate.")
+        raise typer.Exit(2) from e
+    except HulyError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+
+    print_item(data, title=f"Milestone: {data.get('label', milestone_id)}")
+
+
+@app.command("create")
+def milestones_create(
+    ctx: typer.Context,
+    label: Annotated[str, typer.Option("--label", help="Milestone label.")] = ...,
+    project: Annotated[
+        str, typer.Option("--project", help='Project identifier (e.g. "ROA").')
+    ] = ...,
+    status: Annotated[
+        str, typer.Option("--status", help="Status: planned, in-progress, completed.")
+    ] = "planned",
+    target_date: Annotated[
+        str | None, typer.Option("--target-date", help="Target date (YYYY-MM-DD).")
+    ] = None,
+) -> None:
+    """Create a new milestone."""
+    overrides: dict = ctx.obj or {}
+    config = load_config(
+        url_override=overrides.get("url"),
+        workspace_override=overrides.get("workspace"),
+    )
+
+    async def _run() -> str:
+        auth = await ensure_auth(config)
+        async with HulyClient(config, auth) as client:
+            project_id = await _resolve_project_by_identifier(client, project)
+
+            status_int = _resolve_status(status)
+
+            target_date_ms: int | None = None
+            if target_date:
+                try:
+                    target_date_ms = _parse_date_ms(target_date)
+                except ValueError:
+                    raise HulyError(
+                        f"Invalid date format '{target_date}'. Use YYYY-MM-DD."
+                    ) from None
+
+            new_id = secrets.token_hex(12)
+
+            transaction = {
+                "_class": "core:class:TxCreateDoc",
+                "objectClass": "tracker:class:Milestone",
+                "objectSpace": project_id,
+                "objectId": new_id,
+                "attributes": {
+                    "label": label,
+                    "status": status_int,
+                    "targetDate": target_date_ms,
+                    "comments": 0,
+                },
+                "modifiedBy": auth.account_id,
+                "modifiedOn": int(time.time() * 1000),
+            }
+
+            await client.tx(transaction)
+        return new_id
+
+    try:
+        new_id = asyncio.run(_run())
+        print_success(f"Milestone created in project '{project}' (id: {new_id})")
+    except NotFoundError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+    except AuthError as e:
+        print_error(e.message, hint="Run 'huly auth login' to authenticate.")
+        raise typer.Exit(2) from e
+    except HulyError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+
+
+@app.command("update")
+def milestones_update(
+    ctx: typer.Context,
+    milestone_id: str = typer.Argument(..., help="Milestone internal ID."),
+    label: Annotated[str | None, typer.Option("--label", help="New milestone label.")] = None,
+    status: Annotated[
+        str | None, typer.Option("--status", help="New status: planned, in-progress, completed.")
+    ] = None,
+    target_date: Annotated[
+        str | None, typer.Option("--target-date", help="New target date (YYYY-MM-DD).")
+    ] = None,
+) -> None:
+    """Update an existing milestone."""
+    overrides: dict = ctx.obj or {}
+    config = load_config(
+        url_override=overrides.get("url"),
+        workspace_override=overrides.get("workspace"),
+    )
+
+    async def _run() -> None:
+        auth = await ensure_auth(config)
+        async with HulyClient(config, auth) as client:
+            raw = await client.find_all(
+                "tracker:class:Milestone",
+                query={"_id": milestone_id},
+                options={"limit": 1},
+            )
+            if not raw:
+                raise NotFoundError(f"Milestone '{milestone_id}' not found.")
+            milestone = Milestone.model_validate(raw[0])
+
+            operations: dict = {}
+
+            if label is not None:
+                operations["label"] = label
+
+            if status is not None:
+                operations["status"] = _resolve_status(status)
+
+            if target_date is not None:
+                try:
+                    operations["targetDate"] = _parse_date_ms(target_date)
+                except ValueError:
+                    raise HulyError(
+                        f"Invalid date format '{target_date}'. Use YYYY-MM-DD."
+                    ) from None
+
+            if not operations:
+                print_warning(
+                    "No fields to update — provide at least one of --label, --status, --target-date."
+                )
+                return
+
+            transaction = {
+                "_class": "core:class:TxUpdateDoc",
+                "objectClass": "tracker:class:Milestone",
+                "objectSpace": milestone.space,
+                "objectId": milestone.id,
+                "operations": operations,
+                "modifiedBy": auth.account_id,
+                "modifiedOn": int(time.time() * 1000),
+            }
+
+            await client.tx(transaction)
+
+    try:
+        asyncio.run(_run())
+        print_success(f"Milestone {milestone_id} updated.")
+    except NotFoundError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+    except AuthError as e:
+        print_error(e.message, hint="Run 'huly auth login' to authenticate.")
+        raise typer.Exit(2) from e
+    except HulyError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e

--- a/src/huly_cli/commands/templates.py
+++ b/src/huly_cli/commands/templates.py
@@ -1,0 +1,342 @@
+"""Templates commands: list, get, describe."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Annotated, Any
+
+import typer
+
+from huly_cli.auth import ensure_auth
+from huly_cli.client import HulyClient
+from huly_cli.config import load_config
+from huly_cli.errors import AuthError, HulyError, NotFoundError
+from huly_cli.models import IssueTemplate
+from huly_cli.output import (
+    console,
+    is_json_mode,
+    print_error,
+    print_item,
+    print_list,
+    print_success,
+    print_warning,
+)
+
+app = typer.Typer(help="Manage Huly issue templates.", no_args_is_help=True)
+
+
+# ── Shared helpers ────────────────────────────────────────────────────────────
+
+
+def _template_to_row(t: IssueTemplate) -> dict[str, Any]:
+    return {
+        "title": t.title,
+        "priority": t.priority_name,
+        "kind": t.kind,
+        "id": t.id,
+    }
+
+
+def _template_to_detail(t: IssueTemplate) -> dict[str, Any]:
+    return {
+        "title": t.title,
+        "id": t.id,
+        "space": t.space,
+        "priority": t.priority_name,
+        "priority_int": t.priority,
+        "kind": t.kind,
+        "assignee": t.assignee,
+        "component": t.component,
+        "milestone": t.milestone,
+        "estimation": t.estimation,
+        "comments": t.comments,
+        "attachments": t.attachments,
+        "labels": t.labels,
+        "children": len(t.children),
+        "relations": len(t.relations),
+    }
+
+
+# ── Commands ──────────────────────────────────────────────────────────────────
+
+
+@app.command("list")
+def templates_list(
+    ctx: typer.Context,
+    project: Annotated[
+        str | None,
+        typer.Option("--project", "-p", help="Filter by project identifier (e.g. ROA)."),
+    ] = None,
+    limit: Annotated[
+        int,
+        typer.Option("--limit", "-n", help="Maximum number of templates to return."),
+    ] = 50,
+) -> None:
+    """List issue templates, with optional project filter."""
+    overrides: dict = ctx.obj or {}
+    config = load_config(
+        url_override=overrides.get("url"),
+        workspace_override=overrides.get("workspace"),
+    )
+
+    async def _run() -> list[dict[str, Any]]:
+        auth = await ensure_auth(config)
+        async with HulyClient(config, auth) as client:
+            query: dict[str, Any] = {}
+            if project:
+                projects = await client.find_all(
+                    "tracker:class:Project",
+                    query={"identifier": project.upper()},
+                    options={"limit": 1},
+                )
+                if not projects:
+                    raise NotFoundError(f"Project '{project}' not found.")
+                query["space"] = projects[0]["_id"]
+
+            raw = await client.find_all(
+                "tracker:class:IssueTemplate",
+                query=query,
+                options={"limit": limit},
+            )
+            templates = [IssueTemplate.model_validate(doc) for doc in raw]
+
+        return [_template_to_row(t) for t in templates]
+
+    try:
+        rows = asyncio.run(_run())
+    except AuthError as e:
+        print_error(e.message, hint="Run 'huly auth login' to authenticate.")
+        raise typer.Exit(2) from e
+    except HulyError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+
+    print_list(rows, columns=["title", "priority", "kind", "id"], title="Issue Templates")
+
+
+@app.command("get")
+def templates_get(
+    ctx: typer.Context,
+    template_id: str = typer.Argument(..., help="Template internal ID."),
+) -> None:
+    """Get details of an issue template."""
+    overrides: dict = ctx.obj or {}
+    config = load_config(
+        url_override=overrides.get("url"),
+        workspace_override=overrides.get("workspace"),
+    )
+
+    async def _run() -> dict[str, Any]:
+        auth = await ensure_auth(config)
+        async with HulyClient(config, auth) as client:
+            raw = await client.find_all(
+                "tracker:class:IssueTemplate",
+                query={"_id": template_id},
+                options={"limit": 1},
+            )
+            if not raw:
+                raise NotFoundError(f"Template '{template_id}' not found.")
+            template = IssueTemplate.model_validate(raw[0])
+        return _template_to_detail(template)
+
+    try:
+        data = asyncio.run(_run())
+    except NotFoundError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+    except AuthError as e:
+        print_error(e.message, hint="Run 'huly auth login' to authenticate.")
+        raise typer.Exit(2) from e
+    except HulyError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+
+    print_item(data, title=f"Template: {data.get('title', template_id)}")
+
+
+@app.command("describe")
+def templates_describe(
+    ctx: typer.Context,
+    template_id: str = typer.Argument(..., help="Template internal ID."),
+    raw: Annotated[
+        bool,
+        typer.Option("--raw", help="Show raw ProseMirror JSON instead of rendered markdown."),
+    ] = False,
+    set_text: Annotated[
+        str | None,
+        typer.Option("--set", help="Set description from markdown string."),
+    ] = None,
+    set_file: Annotated[
+        str | None,
+        typer.Option("--set-file", help="Set description from a markdown file path."),
+    ] = None,
+) -> None:
+    """Read or update the description of an issue template.
+
+    Template descriptions are stored as inline ProseMirror JSON (not a blob ref).
+    By default, reads and displays the description. Use --set or --set-file to write.
+    """
+    if set_text and set_file:
+        print_error("Use either --set or --set-file, not both.")
+        raise typer.Exit(1)
+
+    overrides: dict = ctx.obj or {}
+    config = load_config(
+        url_override=overrides.get("url"),
+        workspace_override=overrides.get("workspace"),
+    )
+
+    # ── Write path ────────────────────────────────────────────────────────
+    if set_text is not None or set_file is not None:
+        markdown_content = set_text
+        if set_file is not None:
+            import pathlib
+
+            p = pathlib.Path(set_file)
+            if not p.exists():
+                print_error(f"File not found: {set_file}")
+                raise typer.Exit(1)
+            markdown_content = p.read_text(encoding="utf-8")
+
+        async def _write() -> str:
+            import time as time_mod
+
+            from huly_cli.markup import markdown_to_prosemirror
+
+            auth = await ensure_auth(config)
+            async with HulyClient(config, auth) as client:
+                raw_docs = await client.find_all(
+                    "tracker:class:IssueTemplate",
+                    query={"_id": template_id},
+                    options={"limit": 1},
+                )
+                if not raw_docs:
+                    raise NotFoundError(f"Template '{template_id}' not found.")
+                template = IssueTemplate.model_validate(raw_docs[0])
+
+                # Safety: detect if description looks like a blob ref string
+                if (
+                    isinstance(template.description, str)
+                    and "-description-" in template.description
+                ):
+                    raise HulyError(
+                        f"Template '{template_id}' description looks like a blob ref "
+                        f"(contains '-description-'). Aborting to avoid corruption."
+                    )
+
+                markup_json_str = markdown_to_prosemirror(markdown_content or "")
+                description_dict = json.loads(markup_json_str)
+
+                transaction = {
+                    "_class": "core:class:TxUpdateDoc",
+                    "objectClass": "tracker:class:IssueTemplate",
+                    "objectSpace": template.space,
+                    "objectId": template.id,
+                    "operations": {"description": description_dict},
+                    "modifiedBy": auth.account_id,
+                    "modifiedOn": int(time_mod.time() * 1000),
+                }
+                await client.tx(transaction)
+            return template.title or template_id
+
+        try:
+            title_label = asyncio.run(_write())
+        except NotFoundError as e:
+            print_error(e.message)
+            raise typer.Exit(1) from e
+        except AuthError as e:
+            print_error(e.message, hint="Run 'huly auth login' to authenticate.")
+            raise typer.Exit(2) from e
+        except HulyError as e:
+            print_error(e.message)
+            raise typer.Exit(1) from e
+
+        print_success(f"Description updated for '{title_label}'.")
+        return
+
+    # ── Read path ─────────────────────────────────────────────────────────
+    async def _run() -> tuple[str, Any]:
+        auth = await ensure_auth(config)
+        async with HulyClient(config, auth) as client:
+            raw_docs = await client.find_all(
+                "tracker:class:IssueTemplate",
+                query={"_id": template_id},
+                options={"limit": 1},
+            )
+            if not raw_docs:
+                raise NotFoundError(f"Template '{template_id}' not found.")
+            template = IssueTemplate.model_validate(raw_docs[0])
+        return template.title or template_id, template.description
+
+    try:
+        title_label, description = asyncio.run(_run())
+    except NotFoundError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+    except AuthError as e:
+        print_error(e.message, hint="Run 'huly auth login' to authenticate.")
+        raise typer.Exit(2) from e
+    except HulyError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+
+    if not description:
+        print_error(f"No description available for template '{title_label}'.")
+        raise typer.Exit(1)
+
+    # Safety: detect blob ref string
+    if isinstance(description, str) and "-description-" in description:
+        print_warning(
+            f"Template '{title_label}' description looks like a blob ref — "
+            "this template may use a non-standard storage format."
+        )
+
+    # Normalise: description may be a dict (from API) or a string
+    if isinstance(description, dict):
+        raw_json_str = json.dumps(description)
+    else:
+        raw_json_str = str(description)
+
+    if is_json_mode():
+        if raw:
+            print(
+                json.dumps(
+                    {
+                        "ok": True,
+                        "id": template_id,
+                        "description_raw": json.loads(raw_json_str)
+                        if isinstance(description, dict)
+                        else raw_json_str,
+                    }
+                )
+            )
+        else:
+            from huly_cli.markup import prosemirror_to_markdown
+
+            md = prosemirror_to_markdown(raw_json_str)
+            print(json.dumps({"ok": True, "id": template_id, "description": md}))
+        return
+
+    if raw:
+        try:
+            parsed = json.loads(raw_json_str)
+            console.print_json(json.dumps(parsed, indent=2))
+        except (json.JSONDecodeError, TypeError):
+            console.print(raw_json_str)
+    else:
+        from rich.markdown import Markdown
+        from rich.panel import Panel
+
+        from huly_cli.markup import prosemirror_to_markdown
+
+        md_text = prosemirror_to_markdown(raw_json_str)
+        if md_text.strip():
+            console.print(Panel(Markdown(md_text), title=f"Description: {title_label}"))
+        else:
+            from huly_cli.markup import prosemirror_to_text
+
+            plain = prosemirror_to_text(raw_json_str)
+            console.print(
+                Panel(plain or "(empty description)", title=f"Description: {title_label}")
+            )

--- a/src/huly_cli/main.py
+++ b/src/huly_cli/main.py
@@ -6,7 +6,17 @@ from typing import Annotated
 
 import typer
 
-from huly_cli.commands import auth_cmd, issues, labels, members, projects
+from huly_cli.commands import (
+    auth_cmd,
+    components,
+    documents,
+    issues,
+    labels,
+    members,
+    milestones,
+    projects,
+    templates,
+)
 from huly_cli.errors import HulyError, handle_error
 from huly_cli.output import set_json_mode
 
@@ -22,6 +32,10 @@ app.add_typer(projects.app, name="projects")
 app.add_typer(issues.app, name="issues")
 app.add_typer(members.app, name="members")
 app.add_typer(labels.app, name="labels")
+app.add_typer(documents.app, name="documents")
+app.add_typer(components.app, name="components")
+app.add_typer(milestones.app, name="milestones")
+app.add_typer(templates.app, name="templates")
 
 
 @app.callback()

--- a/src/huly_cli/models.py
+++ b/src/huly_cli/models.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from enum import IntEnum
+from typing import Any
 
 from pydantic import BaseModel, Field
 
@@ -114,3 +115,130 @@ class TagReference(BaseModel):
     tag: str
     title: str
     attached_to: str = Field("", alias="attachedTo")
+
+
+# ── Document / Teamspace ──────────────────────────────────────────────────────
+
+
+class Teamspace(BaseModel):
+    model_config = {"populate_by_name": True}
+
+    id: str = Field(alias="_id")
+    name: str
+    description: str = ""
+    private: bool = False
+    archived: bool = False
+    members: list[str] = []
+    owners: list[str] = []
+
+
+class Document(BaseModel):
+    """A Huly document stored in a Teamspace (document:class:Document)."""
+
+    model_config = {"populate_by_name": True}
+
+    id: str = Field(alias="_id")
+    title: str = ""
+    content: str = ""  # blob ref (empty string if no content yet)
+    space: str = ""
+    parent: str = Field("", alias="parent")
+    attachments: int = 0
+    labels: int = 0
+    comments: int = 0
+    rank: str = ""
+    created_by: str = Field("", alias="createdBy")
+    created_on: int = Field(0, alias="createdOn")
+    modified_by: str = Field("", alias="modifiedBy")
+    modified_on: int = Field(0, alias="modifiedOn")
+
+
+# ── Component ─────────────────────────────────────────────────────────────────
+
+
+class Component(BaseModel):
+    """A tracker component scoped to a project (tracker:class:Component)."""
+
+    model_config = {"populate_by_name": True}
+
+    id: str = Field(alias="_id")
+    label: str = ""
+    description: str = ""
+    lead: str | None = None  # Person ID
+    space: str = ""
+    created_by: str = Field("", alias="createdBy")
+    created_on: int = Field(0, alias="createdOn")
+    modified_by: str = Field("", alias="modifiedBy")
+    modified_on: int = Field(0, alias="modifiedOn")
+
+
+# ── Milestone ─────────────────────────────────────────────────────────────────
+
+
+class MilestoneStatus(IntEnum):
+    PLANNED = 0
+    IN_PROGRESS = 1
+    COMPLETED = 2
+    CANCELLED = 3
+
+
+MILESTONE_STATUS_LABELS: dict[int, str] = {
+    0: "planned",
+    1: "in-progress",
+    2: "completed",
+    3: "cancelled",
+}
+
+MILESTONE_STATUS_FROM_NAME: dict[str, int] = {v: k for k, v in MILESTONE_STATUS_LABELS.items()}
+
+
+class Milestone(BaseModel):
+    """A tracker milestone scoped to a project (tracker:class:Milestone)."""
+
+    model_config = {"populate_by_name": True}
+
+    id: str = Field(alias="_id")
+    label: str = ""
+    status: int = 0
+    target_date: int | None = Field(None, alias="targetDate")
+    comments: int = 0
+    space: str = ""
+    created_by: str = Field("", alias="createdBy")
+    created_on: int = Field(0, alias="createdOn")
+    modified_by: str = Field("", alias="modifiedBy")
+    modified_on: int = Field(0, alias="modifiedOn")
+
+    @property
+    def status_name(self) -> str:
+        return MILESTONE_STATUS_LABELS.get(self.status, str(self.status))
+
+
+# ── IssueTemplate ─────────────────────────────────────────────────────────────
+
+
+class IssueTemplate(BaseModel):
+    """An issue template (tracker:class:IssueTemplate).
+
+    The description field stores inline ProseMirror JSON (dict), not a blob ref.
+    """
+
+    model_config = {"populate_by_name": True}
+
+    id: str = Field(alias="_id")
+    title: str = ""
+    description: Any = None  # inline ProseMirror dict or empty string
+    assignee: str | None = None
+    component: str | None = None
+    milestone: str | None = None
+    priority: int = 0
+    estimation: int = 0
+    children: list[Any] = []
+    comments: int = 0
+    attachments: int = 0
+    labels: int = 0
+    kind: str = ""
+    relations: list[Any] = []
+    space: str = ""
+
+    @property
+    def priority_name(self) -> str:
+        return PRIORITY_LABELS.get(self.priority, str(self.priority))

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -287,3 +287,114 @@ def test_issues_list_json_mode():
     assert data["ok"] is True
     assert len(data["data"]) == 1
     assert data["data"][0]["title"] == "Fix bug"
+
+
+# ── documents list ─────────────────────────────────────────────────────────────
+
+DOCUMENT_DATA = [
+    {
+        "_id": "doc1",
+        "title": "My Doc",
+        "content": "blob-ref-123",
+        "space": "ts1",
+        "parent": "document:ids:NoParent",
+        "attachments": 0,
+        "labels": 0,
+        "comments": 0,
+        "rank": "",
+        "createdBy": "",
+        "createdOn": 0,
+        "modifiedBy": "",
+        "modifiedOn": 0,
+    }
+]
+
+TEAMSPACE_DATA = [
+    {
+        "_id": "ts1",
+        "name": "Engineering",
+        "description": "",
+        "private": False,
+        "archived": False,
+        "members": [],
+        "owners": [],
+    }
+]
+
+
+def test_documents_list():
+    # find_all called twice: once for teamspaces, once for documents
+    find_mock = AsyncMock(side_effect=[TEAMSPACE_DATA, DOCUMENT_DATA])
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["documents", "list"])
+    assert result.exit_code == 0, result.output
+    assert "My Doc" in result.output
+
+
+def test_documents_list_empty():
+    find_mock = AsyncMock(side_effect=[TEAMSPACE_DATA, []])
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["documents", "list"])
+    assert result.exit_code == 0
+
+
+def test_documents_list_shows_space():
+    find_mock = AsyncMock(side_effect=[TEAMSPACE_DATA, DOCUMENT_DATA])
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["documents", "list"])
+    assert result.exit_code == 0, result.output
+    assert "Engineering" in result.output
+
+
+# ── components list ────────────────────────────────────────────────────────────
+
+COMPONENT_DATA = [
+    {
+        "_id": "c1",
+        "label": "Auth Service",
+        "description": "Handles authentication",
+        "lead": None,
+        "space": "proj1",
+        "createdBy": "",
+        "createdOn": 0,
+        "modifiedBy": "",
+        "modifiedOn": 0,
+    }
+]
+
+
+def test_components_list():
+    # find_all called twice: once for components, once for persons
+    find_mock = AsyncMock(side_effect=[COMPONENT_DATA, []])
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["components", "list"])
+    assert result.exit_code == 0, result.output
+    assert "Auth Service" in result.output
+
+
+def test_components_list_empty():
+    find_mock = AsyncMock(side_effect=[[], []])
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["components", "list"])
+    assert result.exit_code == 0
+
+
+def test_components_list_shows_description():
+    find_mock = AsyncMock(side_effect=[COMPONENT_DATA, []])
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["components", "list"])
+    assert result.exit_code == 0, result.output
+    assert "Auth Service" in result.output
+
+
+def test_components_list_json_mode():
+    import json as json_mod
+
+    find_mock = AsyncMock(side_effect=[COMPONENT_DATA, []])
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["--json", "components", "list"])
+    assert result.exit_code == 0, result.output
+    data = json_mod.loads(result.output)
+    assert data["ok"] is True
+    assert isinstance(data["data"], list)
+    assert data["data"][0]["label"] == "Auth Service"

--- a/tests/test_commands_new.py
+++ b/tests/test_commands_new.py
@@ -1,0 +1,240 @@
+"""Regression tests for milestones and templates CLI commands."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+from typer.testing import CliRunner
+
+from huly_cli.config import AuthCache
+from huly_cli.main import app
+
+runner = CliRunner()
+
+FAKE_AUTH = AuthCache(
+    account_token="t",
+    workspace_token="t",
+    workspace_id="w",
+    workspace_uuid="u",
+    email="test@test.com",
+    workspace_slug="test",
+    account_id="a",
+    cached_at=1.0,
+)
+
+
+def _auth_patch():
+    """Patch ensure_auth to return FAKE_AUTH directly (used by all sub-commands)."""
+    return patch("huly_cli.auth.ensure_auth", new=AsyncMock(return_value=FAKE_AUTH))
+
+
+# ── milestones list ────────────────────────────────────────────────────────────
+
+MILESTONE_DATA = [
+    {
+        "_id": "m1",
+        "label": "Sprint 1",
+        "status": 0,
+        "targetDate": None,
+        "comments": 0,
+        "space": "p1",
+        "createdBy": "",
+        "createdOn": 0,
+        "modifiedBy": "",
+        "modifiedOn": 0,
+    }
+]
+
+
+def test_milestones_list():
+    find_mock = AsyncMock(return_value=MILESTONE_DATA)
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["milestones", "list"])
+    assert result.exit_code == 0, result.output
+    assert "Sprint 1" in result.output
+
+
+def test_milestones_list_shows_status():
+    find_mock = AsyncMock(return_value=MILESTONE_DATA)
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["milestones", "list"])
+    assert result.exit_code == 0, result.output
+    assert "planned" in result.output.lower()
+
+
+def test_milestones_list_empty():
+    find_mock = AsyncMock(return_value=[])
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["milestones", "list"])
+    assert result.exit_code == 0
+
+
+def test_milestones_list_json_mode():
+    import json as json_mod
+
+    find_mock = AsyncMock(return_value=MILESTONE_DATA)
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["--json", "milestones", "list"])
+    assert result.exit_code == 0, result.output
+    data = json_mod.loads(result.output)
+    assert data["ok"] is True
+    assert isinstance(data["data"], list)
+
+
+def test_milestones_list_with_project_filter():
+    project_data = [{"_id": "p1", "identifier": "TP", "name": "Test Project"}]
+    find_mock = AsyncMock(side_effect=[project_data, MILESTONE_DATA])
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["milestones", "list", "--project", "TP"])
+    assert result.exit_code == 0, result.output
+    assert "Sprint 1" in result.output
+
+
+# ── templates list ─────────────────────────────────────────────────────────────
+
+TEMPLATE_DATA = [
+    {
+        "_id": "tmpl1",
+        "title": "Bug Report",
+        "description": "",
+        "assignee": None,
+        "component": None,
+        "milestone": None,
+        "priority": 1,
+        "estimation": 0,
+        "children": [],
+        "comments": 0,
+        "attachments": 0,
+        "labels": 0,
+        "kind": "",
+        "relations": [],
+        "space": "p1",
+    }
+]
+
+
+def test_templates_list():
+    find_mock = AsyncMock(return_value=TEMPLATE_DATA)
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["templates", "list"])
+    assert result.exit_code == 0, result.output
+    assert "Bug Report" in result.output
+
+
+def test_templates_list_shows_priority():
+    find_mock = AsyncMock(return_value=TEMPLATE_DATA)
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["templates", "list"])
+    assert result.exit_code == 0, result.output
+    assert "Urgent" in result.output
+
+
+def test_templates_list_empty():
+    find_mock = AsyncMock(return_value=[])
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["templates", "list"])
+    assert result.exit_code == 0
+
+
+def test_templates_list_json_mode():
+    import json as json_mod
+
+    find_mock = AsyncMock(return_value=TEMPLATE_DATA)
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["--json", "templates", "list"])
+    assert result.exit_code == 0, result.output
+    data = json_mod.loads(result.output)
+    assert data["ok"] is True
+    assert len(data["data"]) == 1
+    assert data["data"][0]["title"] == "Bug Report"
+
+
+def test_templates_list_multiple():
+    template_data = [
+        {
+            "_id": "t1",
+            "title": "Template A",
+            "description": "",
+            "priority": 0,
+            "kind": "",
+            "space": "p1",
+            "assignee": None,
+            "component": None,
+            "milestone": None,
+            "estimation": 0,
+            "children": [],
+            "comments": 0,
+            "attachments": 0,
+            "labels": 0,
+            "relations": [],
+        },
+        {
+            "_id": "t2",
+            "title": "Template B",
+            "description": "",
+            "priority": 2,
+            "kind": "",
+            "space": "p1",
+            "assignee": None,
+            "component": None,
+            "milestone": None,
+            "estimation": 0,
+            "children": [],
+            "comments": 0,
+            "attachments": 0,
+            "labels": 0,
+            "relations": [],
+        },
+    ]
+    find_mock = AsyncMock(return_value=template_data)
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["templates", "list"])
+    assert result.exit_code == 0, result.output
+    assert "Template A" in result.output
+    assert "Template B" in result.output
+
+
+def test_templates_list_with_project_filter():
+    project_data = [{"_id": "p1", "identifier": "TP", "name": "Test Project"}]
+    find_mock = AsyncMock(side_effect=[project_data, TEMPLATE_DATA])
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["templates", "list", "--project", "TP"])
+    assert result.exit_code == 0, result.output
+    assert "Bug Report" in result.output
+
+
+def test_milestones_list_multiple_statuses():
+    """Milestones with different statuses should all appear."""
+    milestone_data = [
+        {
+            "_id": "m1",
+            "label": "Sprint 1",
+            "status": 0,
+            "targetDate": None,
+            "comments": 0,
+            "space": "p1",
+            "createdBy": "",
+            "createdOn": 0,
+            "modifiedBy": "",
+            "modifiedOn": 0,
+        },
+        {
+            "_id": "m2",
+            "label": "Sprint 2",
+            "status": 2,
+            "targetDate": 1700000000000,
+            "comments": 0,
+            "space": "p1",
+            "createdBy": "",
+            "createdOn": 0,
+            "modifiedBy": "",
+            "modifiedOn": 0,
+        },
+    ]
+    find_mock = AsyncMock(return_value=milestone_data)
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["milestones", "list"])
+    assert result.exit_code == 0, result.output
+    assert "Sprint 1" in result.output
+    assert "Sprint 2" in result.output
+    assert "completed" in result.output.lower()


### PR DESCRIPTION
## Summary

Extends the CLI with four new entity types, each with its own storage quirks.

- `huly documents list/get/create/update/describe` — documents live in teamspaces (not projects); content is a blob ref accessed via Collaborator RPC with field `"content"`
- `huly components list/get/create/update` — project-scoped, optional `--lead` with fuzzy person match
- `huly milestones list/get/create/update` — project-scoped, `--target-date YYYY-MM-DD` parsing, status enum (planned/in-progress/completed)
- `huly templates list/get/describe` — descriptions are inline ProseMirror JSON (not blob refs), so reads/writes go through `TxUpdateDoc` directly; safety check prevents corruption if a blob ref is detected
- Collaborator RPC generalized to `get_content(class_id, object_id, field, blob_ref)` — works for any entity, not just issues

## Context

- Template `describe --set` includes a safety check: if the description field looks like a blob ref (`*-description-*` pattern), it aborts rather than corrupting data by overwriting the ref with raw JSON
- `get_description`/`set_description` remain as convenience wrappers for backward compatibility
- Components and milestones are currently empty in the EFS workspace but the API classes are verified queryable