### PR TITLE
fix: align huly-cli with Huly platform v0.6.504

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Minimal required config
+HULY_URL=https://huly.ingenuity.ph
+HULY_WORKSPACE=efs
+
+# Optional for interactive local use.
+# Recommended for non-interactive runs or automatic re-auth when the cached token expires.
+HULY_EMAIL=you@example.com
+HULY_PASSWORD=your-password

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ __pycache__/
 .ruff_cache/
 .venv/
 *.egg-info/
+.specstory/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -1,47 +1,269 @@
 # huly-cli
 
-A command-line interface for interacting with [Huly](https://huly.io) project management — built for agents and humans alike.
+Python CLI for interacting with a Huly workspace from the terminal.
 
-## Overview
+## Status
 
-`huly-cli` provides terminal access to your Huly instance for managing issues, projects, and workflows. It supports both Huly Cloud and self-hosted instances.
+This repo is currently a Python `typer` CLI, not a Node or `pnpm` project.
 
-### Features
+It has been checked against `hcengineering/platform@v0.6.504` and smoke-tested against
+`https://huly.ingenuity.ph` workspace `efs`.
 
-- **Authentication** — Login, workspace selection, and token management
-- **Issues** — List, create, update, and query issues with full filter support
-- **Projects** — Browse projects and their configurations
-- **Statuses & Labels** — View and manage workflow states and tags
+What is verified today:
+
+- Authentication flow via `/_accounts`
+- Read-only access for projects, issues, components, documents, templates, members, labels, and issue descriptions
+- Workspace-specific issue status display and status filtering
+- Local unit/CLI test suite
+- CI-equivalent local checks:
+  `uv sync --extra dev`, `uv run ruff check .`, `uv run ruff format --check .`, and `uv run pytest tests/ -v`
+
+What is not fully verified yet:
+
+- Live write commands were not executed against the shared workspace
+- Issue create/update semantics are aligned to the upstream client flow, but still only verified locally with mocked tests
+
+Known live compatibility gaps at the time of writing:
+
+- No known read-path breakage remains from the `v0.6.504` comparison and smoke tests
+- Write paths should still be exercised in a disposable project before you rely on them for production changes
+- The test suite now patches auth correctly; it no longer depends on a developer's local cached login state
+
+## Compatibility Target
+
+- Huly platform tag: `v0.6.504`
+- Example workspace URL used during verification:
+  `https://huly.ingenuity.ph/workbench/efs/tracker/69cb986a2df46a01935af670/issues`
+
+Important distinction:
+
+- `efs` is the workspace slug
+- `ROA` is the project identifier in that workspace
+
+If you run `huly issues list --project EFS`, it will fail because `EFS` is not a project ID.
 
 ## Prerequisites
 
-- Node.js 18+
-- A Huly account (cloud or self-hosted)
+- Python `3.11+`
+- [`uv`](https://docs.astral.sh/uv/)
+- A Huly account with access to the target workspace
 
 ## Setup
 
+1. Install dependencies, including dev tools:
+
 ```bash
-# Install dependencies
-pnpm install
-
-# Build
-pnpm build
-
-# Login to your Huly instance
-huly login --url https://your-instance.example.com
+uv sync --extra dev
 ```
 
-## Usage
+2. Copy the example environment file:
 
 ```bash
-# List issues in a project
-huly issues list --project EFS
+cp .env.example .env
+```
 
-# Create a new issue
-huly issues create --project EFS --title "Fix login bug" --priority urgent
+3. Edit `.env` with at least:
 
-# View issue details
-huly issues get EFS-123
+- `HULY_URL`
+- `HULY_WORKSPACE`
+
+4. Choose one auth approach:
+
+- Interactive login: preferred for local use
+- Environment-based login: useful for non-interactive runs and token refresh
+
+## Environment Variables
+
+The CLI loads config in this order:
+
+1. CLI flags
+2. Environment variables
+3. `.env` in the current directory
+4. `~/.config/huly/config.toml`
+
+Supported variables:
+
+- `HULY_URL`
+- `HULY_WORKSPACE`
+- `HULY_EMAIL`
+- `HULY_PASSWORD`
+
+Auth cache location:
+
+- Config: `~/.config/huly/config.toml`
+- Tokens: `~/.config/huly/auth.json`
+
+The token cache is reused automatically. If the cached token expires, the CLI needs
+`HULY_EMAIL` and `HULY_PASSWORD` available in order to re-authenticate automatically.
+
+## Login Walkthrough
+
+### Option 1: Interactive login
+
+This is the simplest flow if you are testing locally and do not want to keep your password
+in `.env`.
+
+```bash
+uv run huly --url https://huly.ingenuity.ph --workspace efs auth login
+```
+
+You will be prompted for:
+
+- Email
+- Password
+- Workspace slug, if it was not passed on the command line or set in `.env`
+
+Then confirm auth is valid:
+
+```bash
+uv run huly auth status
+```
+
+### Option 2: Login using `.env`
+
+Put all four values in `.env`:
+
+```bash
+HULY_URL=https://huly.ingenuity.ph
+HULY_WORKSPACE=efs
+HULY_EMAIL=you@example.com
+HULY_PASSWORD=your-password
+```
+
+Then run:
+
+```bash
+uv run huly auth login
+uv run huly auth status
+```
+
+## Hands-On Smoke Test
+
+These commands are the safest live checks to run today.
+
+1. Confirm auth:
+
+```bash
+uv run huly auth status
+```
+
+2. List projects:
+
+```bash
+uv run huly projects list
+```
+
+3. Inspect the verified sample project:
+
+```bash
+uv run huly projects get ROA
+```
+
+4. List a few issues from that project:
+
+```bash
+uv run huly issues list --project ROA --limit 5
+```
+
+5. Inspect one issue:
+
+```bash
+uv run huly issues get ROA-1
+```
+
+6. Read the issue description:
+
+```bash
+uv run huly issues describe ROA-1
+```
+
+7. List project components:
+
+```bash
+uv run huly components list --project ROA --limit 5
+```
+
+8. Inspect a component by internal ID:
+
+```bash
+uv run huly components get 16e202fa79377835295c79eb
+```
+
+9. List a few documents:
+
+```bash
+uv run huly documents list --limit 5
+```
+
+10. List issue templates:
+
+```bash
+uv run huly templates list --limit 5
+```
+
+11. Verify status filtering:
+
+```bash
+uv run huly issues list --status backlog --limit 5
+```
+
+12. List workspace members:
+
+```bash
+uv run huly members list
+```
+
+13. List labels:
+
+```bash
+uv run huly labels list
+```
+
+### JSON mode
+
+If you want machine-readable output for quick inspection:
+
+```bash
+uv run huly --json projects list
+uv run huly --json issues list --project ROA --limit 5
+uv run huly --json auth status
+```
+
+## Commands That Currently Need Caution
+
+Avoid treating the following as production-safe until you have exercised them in a disposable project:
+
+- `huly issues create`
+- `huly issues update`
+- `huly issues describe --set ...`
+- Any other create or update command against a real workspace
+
+If you are doing live validation, stay on read-only commands first.
+
+## Local Test Suite
+
+Run the unit and CLI regression tests with:
+
+```bash
+uv run --extra dev pytest -q
+```
+
+Expected result at the time of verification:
+
+- `146 passed`
+
+## CLI Help
+
+Top-level help:
+
+```bash
+uv run huly --help
+```
+
+Auth help:
+
+```bash
+uv run huly auth login --help
 ```
 
 ## License

--- a/src/huly_cli/client.py
+++ b/src/huly_cli/client.py
@@ -32,9 +32,10 @@ class HulyClient:
         options: dict[str, Any] | None = None,
     ) -> list[dict[str, Any]]:
         """Query documents via POST /api/v1/find-all/{workspace_id}."""
+        query = query or {}
         body = {
             "_class": class_id,
-            "query": query or {},
+            "query": query,
             "options": options or {},
         }
         resp = await self._http.post(
@@ -42,7 +43,7 @@ class HulyClient:
             json=body,
         )
         data = self._handle_response(resp)
-        return data.get("value", [])
+        return self._normalize_find_all_result(class_id, query, data)
 
     async def tx(self, transaction: dict[str, Any]) -> dict[str, Any]:
         """Execute a transaction via POST /api/v1/tx/{workspace_id}."""
@@ -105,6 +106,41 @@ class HulyClient:
             print_warning(f"getContent error: {e}")
             return None
 
+    async def create_content(
+        self, class_id: str, object_id: str, field: str, markup_json: str
+    ) -> str | None:
+        """Create entity content via Collaborator RPC and return its blob ref."""
+        doc_id = self._build_doc_id(class_id, object_id, field)
+        url = f"{self._config.url}/_collaborator/rpc/{doc_id}"
+        try:
+            async with httpx.AsyncClient(timeout=15.0) as http:
+                resp = await http.post(
+                    url,
+                    headers={
+                        "Authorization": f"Bearer {self._auth.workspace_token}",
+                        "Content-Type": "application/json",
+                    },
+                    json={
+                        "method": "createContent",
+                        "payload": {
+                            "content": {field: json_mod.loads(markup_json)},
+                        },
+                    },
+                )
+                if resp.status_code != 200:
+                    print_warning(
+                        f"createContent failed (HTTP {resp.status_code}): {resp.text[:200]}"
+                    )
+                    return None
+                data = resp.json()
+                blob_ref = data.get("content", {}).get(field)
+                if blob_ref is None:
+                    return None
+                return str(blob_ref)
+        except Exception as e:
+            print_warning(f"createContent error: {e}")
+            return None
+
     async def set_content(
         self, class_id: str, object_id: str, field: str, blob_ref: str, markup_json: str
     ) -> bool:
@@ -147,6 +183,12 @@ class HulyClient:
         """
         return await self.get_content("tracker:class:Issue", issue_id, "description", blob_ref)
 
+    async def create_description(self, issue_id: str, markup_json: str) -> str | None:
+        """Create issue description content and return the blob ref."""
+        return await self.create_content(
+            "tracker:class:Issue", issue_id, "description", markup_json
+        )
+
     async def set_description(self, issue_id: str, blob_ref: str, markup_json: str) -> bool:
         """Update issue description via Collaborator RPC.
 
@@ -182,6 +224,52 @@ class HulyClient:
             return resp.json()
         except Exception:
             return {}
+
+    def _normalize_find_all_result(
+        self,
+        class_id: str,
+        query: dict[str, Any],
+        data: dict[str, Any] | list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        """Mirror the upstream REST client normalization for `find-all`.
+
+        The platform client restores scalar query values that may be omitted in
+        filtered results and resolves lookup references using the response's
+        `lookupMap`.
+        """
+        if isinstance(data, dict):
+            lookup_map = data.pop("lookupMap", None)
+            rows = data.get("value", [])
+        else:
+            lookup_map = None
+            rows = data
+
+        if not isinstance(rows, list):
+            return []
+
+        if isinstance(lookup_map, dict):
+            for row in rows:
+                if not isinstance(row, dict):
+                    continue
+                lookup = row.get("$lookup")
+                if not isinstance(lookup, dict):
+                    continue
+                for key, value in list(lookup.items()):
+                    if isinstance(value, list):
+                        lookup[key] = [lookup_map.get(item) for item in value]
+                    else:
+                        lookup[key] = lookup_map.get(value)
+
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            if row.get("_class") is None:
+                row["_class"] = class_id
+            for key, value in query.items():
+                if isinstance(value, (str, int, bool)) and row.get(key) is None:
+                    row[key] = value
+
+        return rows
 
     # ── Context manager ───────────────────────────────────────────────────────
 

--- a/src/huly_cli/commands/issues.py
+++ b/src/huly_cli/commands/issues.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import json
 import secrets
-import time
 from typing import Annotated, Any
 
 import typer
@@ -14,12 +13,15 @@ from huly_cli.auth import ensure_auth
 from huly_cli.client import HulyClient
 from huly_cli.config import load_config
 from huly_cli.errors import AuthError, HulyError, NotFoundError
-from huly_cli.models import (
-    PRIORITY_FROM_NAME,
-    STATUS_IDS,
-    Issue,
-    Person,
+from huly_cli.issue_utils import (
+    IssueStatusIndex,
+    load_issue_status_index,
+    next_rank,
+    resolve_status_id,
+    resolve_status_ids,
+    status_label,
 )
+from huly_cli.models import PRIORITY_FROM_NAME, STATUS_IDS, Issue, Person, Project
 from huly_cli.output import (
     console,
     is_json_mode,
@@ -43,28 +45,152 @@ async def _fetch_person_map(client: HulyClient) -> dict[str, str]:
     return {p.id: p.display_name for p in persons}
 
 
-def _resolve_status_filter(status_name: str) -> str | None:
-    key = status_name.lower().replace(" ", "-")
-    return STATUS_IDS.get(key)
+def _normalize_issue_doc(raw: dict[str, Any]) -> dict[str, Any]:
+    """Coerce live issue documents into the local model's shape."""
+    normalized = dict(raw)
+    if normalized.get("description") is None:
+        normalized["description"] = ""
+    return normalized
 
 
-def _issue_to_row(issue: Issue, person_map: dict[str, str]) -> dict[str, Any]:
+def _issue_from_raw(raw: dict[str, Any]) -> Issue:
+    return Issue.model_validate(_normalize_issue_doc(raw))
+
+
+async def _resolve_project_by_identifier(client: HulyClient, identifier: str) -> Project:
+    projects = await client.find_all(
+        "tracker:class:Project",
+        query={"identifier": identifier.upper()},
+        options={"limit": 1},
+    )
+    if not projects:
+        raise NotFoundError(f"Project '{identifier}' not found.")
+    return Project.model_validate(projects[0])
+
+
+async def _find_issue_by_identifier_or_id(client: HulyClient, identifier: str) -> Issue:
+    lookup = identifier.upper()
+    raw_docs = await client.find_all(
+        "tracker:class:Issue",
+        query={"identifier": lookup},
+        options={"limit": 1},
+    )
+    if not raw_docs:
+        raw_docs = await client.find_all(
+            "tracker:class:Issue",
+            query={"_id": identifier},
+            options={"limit": 1},
+        )
+    if not raw_docs:
+        raise NotFoundError(f"Issue '{identifier}' not found.")
+    return _issue_from_raw(raw_docs[0])
+
+
+def _format_status_label(issue: Issue, status_index: IssueStatusIndex | None = None) -> str:
+    """Prefer the live status index when the built-in mapping cannot resolve a value."""
+    label = issue.status_name
+    if label == issue.status:
+        return status_label(issue.status, status_index)
+    return label
+
+
+async def _resolve_person_by_name(client: HulyClient, name: str) -> str:
+    """Fuzzy-match a person by name and return their ID."""
+    raw = await client.find_all("contact:class:Person", options={"limit": 500})
+    needle = name.lower()
+    for doc in raw:
+        person = Person.model_validate(doc)
+        if needle in person.display_name.lower() or needle in person.name.lower():
+            return person.id
+    raise NotFoundError(f"Person '{name}' not found.")
+
+
+def _resolve_priority_value(priority: str) -> int:
+    """Resolve a priority name or numeric string to the tracker integer value."""
+    try:
+        return int(priority)
+    except ValueError:
+        priority_int = PRIORITY_FROM_NAME.get(priority.lower())
+        if priority_int is None:
+            valid = ", ".join(PRIORITY_FROM_NAME.keys())
+            raise HulyError(f"Unknown priority '{priority}'. Valid values: {valid}") from None
+        return priority_int
+
+
+async def _resolve_issue_status_id(
+    client: HulyClient,
+    raw_status: str | None,
+    *,
+    preferred: str | None = None,
+) -> str:
+    """Resolve a status name/id to the concrete status id used by the workspace."""
+    if raw_status is None:
+        return preferred or STATUS_IDS["backlog"]
+
+    status_index = await load_issue_status_index(client)
+    try:
+        return resolve_status_id(raw_status, status_index, preferred=preferred)
+    except ValueError as exc:
+        valid = ", ".join(status_index.available_labels())
+        raise HulyError(f"Unknown status '{raw_status}'. Valid values: {valid}") from exc
+
+
+async def _next_issue_number_and_rank(
+    client: HulyClient,
+    project: Project,
+) -> tuple[int, str, str]:
+    """Increment the project sequence and derive the new issue identifier and rank."""
+    raw = await client.find_all(
+        "tracker:class:Issue",
+        query={"space": project.id},
+        options={"limit": 1, "sort": {"rank": -1}},
+    )
+    last_rank = raw[0].get("rank") if raw else None
+
+    increment_result = await client.tx(
+        {
+            "_class": "core:class:TxUpdateDoc",
+            "objectClass": "tracker:class:Project",
+            "objectSpace": "core:space:Space",
+            "objectId": project.id,
+            "operations": {"$inc": {"sequence": 1}},
+            "retrieve": True,
+        }
+    )
+    number = increment_result.get("object", {}).get("sequence")
+    if not isinstance(number, int):
+        number = project.sequence + 1
+
+    identifier = f"{project.identifier}-{number}" if project.identifier else str(number)
+    return number, identifier, next_rank(last_rank)
+
+
+def _issue_to_row(
+    issue: Issue,
+    person_map: dict[str, str],
+    status_index: IssueStatusIndex | None = None,
+) -> dict[str, Any]:
     assignee_name = person_map.get(issue.assignee, issue.assignee) if issue.assignee else ""
     return {
         "identifier": issue.identifier or issue.id,
         "title": issue.title,
-        "status": issue.status_name,
+        "status": _format_status_label(issue, status_index),
         "priority": issue.priority_name,
         "assignee": assignee_name,
     }
 
 
-def _issue_to_detail(issue: Issue, person_map: dict[str, str]) -> dict[str, Any]:
+def _issue_to_detail(
+    issue: Issue,
+    person_map: dict[str, str],
+    status_index: IssueStatusIndex | None = None,
+) -> dict[str, Any]:
     assignee_name = person_map.get(issue.assignee, issue.assignee) if issue.assignee else ""
     return {
         "identifier": issue.identifier or issue.id,
         "title": issue.title,
-        "status": issue.status_name,
+        "status": _format_status_label(issue, status_index),
+        "status_id": issue.status,
         "priority": issue.priority_name,
         "assignee": assignee_name,
         "id": issue.id,
@@ -119,25 +245,57 @@ def issues_list(
         auth = await ensure_auth(config)
         async with HulyClient(config, auth) as client:
             query: dict[str, Any] = {}
-            if status:
-                status_id = _resolve_status_filter(status)
-                if not status_id:
-                    valid = ", ".join(STATUS_IDS.keys())
-                    raise HulyError(f"Unknown status '{status}'. Valid values: {valid}")
-                query["status"] = status_id
-
-            raw = await client.find_all(
-                "tracker:class:Issue",
-                query=query,
-                options={"limit": limit},
-            )
-            issues = [Issue.model_validate(doc) for doc in raw]
+            status_index: IssueStatusIndex | None = None
+            status_ids: list[str] = []
 
             if project:
-                prefix = project.upper() + "-"
-                issues = [i for i in issues if i.identifier.upper().startswith(prefix)]
+                project_doc = await _resolve_project_by_identifier(client, project)
+                query["space"] = project_doc.id
+
+            if status:
+                status_ids = resolve_status_ids(status, status_index)
+                if not status_ids:
+                    status_index = await load_issue_status_index(client)
+                    status_ids = resolve_status_ids(status, status_index)
+                if not status_ids:
+                    valid = ", ".join(
+                        status_index.available_labels() if status_index else STATUS_IDS.keys()
+                    )
+                    raise HulyError(f"Unknown status '{status}'. Valid values: {valid}")
+
+            if len(status_ids) <= 1:
+                if status_ids:
+                    query["status"] = status_ids[0]
+                raw = await client.find_all(
+                    "tracker:class:Issue",
+                    query=query,
+                    options={"limit": limit},
+                )
+            else:
+                raw = []
+                seen: set[str] = set()
+                for status_id in status_ids:
+                    scoped_query = {**query, "status": status_id}
+                    scoped_rows = await client.find_all(
+                        "tracker:class:Issue",
+                        query=scoped_query,
+                        options={"limit": limit},
+                    )
+                    for doc in scoped_rows:
+                        doc_id = doc.get("_id")
+                        if not isinstance(doc_id, str) or doc_id in seen:
+                            continue
+                        seen.add(doc_id)
+                        raw.append(doc)
+                        if len(raw) >= limit:
+                            break
+                    if len(raw) >= limit:
+                        break
+            issues = [_issue_from_raw(doc) for doc in raw]
 
             person_map = await _fetch_person_map(client)
+            if status_index is None and any(issue.status_name == issue.status for issue in issues):
+                status_index = await load_issue_status_index(client)
 
         if assignee:
             needle = assignee.lower()
@@ -145,7 +303,7 @@ def issues_list(
                 i for i in issues if i.assignee and needle in person_map.get(i.assignee, "").lower()
             ]
 
-        return [_issue_to_row(i, person_map) for i in issues]
+        return [_issue_to_row(i, person_map, status_index) for i in issues]
 
     try:
         rows = asyncio.run(_run())
@@ -178,16 +336,12 @@ def issues_get(
     async def _run() -> dict[str, Any]:
         auth = await ensure_auth(config)
         async with HulyClient(config, auth) as client:
-            raw = await client.find_all(
-                "tracker:class:Issue",
-                query={"identifier": identifier.upper()},
-                options={"limit": 1},
-            )
-            if not raw:
-                raise NotFoundError(f"Issue '{identifier}' not found.")
-            issue = Issue.model_validate(raw[0])
+            issue = await _find_issue_by_identifier_or_id(client, identifier)
             person_map = await _fetch_person_map(client)
-        return _issue_to_detail(issue, person_map)
+            status_index = None
+            if issue.status_name == issue.status:
+                status_index = await load_issue_status_index(client)
+        return _issue_to_detail(issue, person_map, status_index)
 
     try:
         data = asyncio.run(_run())
@@ -211,7 +365,7 @@ def issues_create(
     project: Annotated[
         str, typer.Option("--project", help='Project identifier (e.g. "ROA").')
     ] = ...,
-    status: Annotated[str, typer.Option("--status", help="Status name.")] = "backlog",
+    status: Annotated[str | None, typer.Option("--status", help="Status name or id.")] = None,
     priority: Annotated[str, typer.Option("--priority", help="Priority name or number.")] = "none",
     assignee: Annotated[
         str | None, typer.Option("--assignee", help="Assignee person name (fuzzy match).")
@@ -243,111 +397,69 @@ async def _create_impl(
     config,
     title: str,
     project: str,
-    status: str,
+    status: str | None,
     priority: str,
     assignee: str | None,
     description: str | None,
 ) -> str:
     auth = await ensure_auth(config)
     async with HulyClient(config, auth) as client:
-        # Resolve project by identifier (normalise to uppercase, e.g. "roa" → "ROA")
-        projects = await client.find_all("tracker:class:Project", {"identifier": project.upper()})
-        if not projects:
-            raise NotFoundError(f"Project '{project}' not found.")
-        proj = projects[0]
-        project_id: str = proj["_id"]
-
-        # Resolve status
-        status_key = status.lower().replace(" ", "-")
-        status_id = STATUS_IDS.get(status_key)
-        if status_id is None:
-            raise NotFoundError(
-                f"Unknown status '{status}'. Valid values: {', '.join(STATUS_IDS.keys())}"
-            )
-
-        # Resolve priority
-        try:
-            priority_int = int(priority)
-        except ValueError:
-            priority_int = PRIORITY_FROM_NAME.get(priority.lower())
-            if priority_int is None:
-                raise NotFoundError(
-                    f"Unknown priority '{priority}'. Valid values: {', '.join(PRIORITY_FROM_NAME.keys())}"
-                ) from None
-
-        # Resolve assignee
-        person_id: str | None = None
-        if assignee:
-            persons = await client.find_all("contact:class:Person")
-            query_lower = assignee.lower()
-            match = None
-            for p in persons:
-                name: str = p.get("name", "")
-                # Build display name for matching: "LastName,FirstName" -> "FirstName LastName"
-                parts = name.split(",", 1)
-                display = f"{parts[1].strip()} {parts[0].strip()}" if len(parts) == 2 else name
-                if query_lower in display.lower() or query_lower in name.lower():
-                    match = p
-                    break
-            if match is None:
-                raise NotFoundError(f"Person '{assignee}' not found.")
-            person_id = match["_id"]
-
-        # Generate new issue ID
+        project_doc = await _resolve_project_by_identifier(client, project)
+        status_id = await _resolve_issue_status_id(
+            client,
+            status,
+            preferred=project_doc.default_issue_status or None,
+        )
+        priority_int = _resolve_priority_value(priority)
+        person_id = await _resolve_person_by_name(client, assignee) if assignee else None
         new_id = secrets.token_hex(12)
+        number, identifier_value, rank = await _next_issue_number_and_rank(client, project_doc)
+
+        description_ref: str | None = None
+        if description:
+            from huly_cli.markup import markdown_to_prosemirror
+
+            markup = markdown_to_prosemirror(description)
+            description_ref = await client.create_description(new_id, markup)
+            if not description_ref:
+                raise HulyError("Failed to create issue description content via Collaborator RPC.")
 
         transaction = {
             "_class": "core:class:TxCreateDoc",
             "objectClass": "tracker:class:Issue",
-            "objectSpace": project_id,
+            "objectSpace": project_doc.id,
             "objectId": new_id,
             "attributes": {
                 "title": title,
-                "description": "",
+                "description": description_ref,
                 "status": status_id,
                 "priority": priority_int,
                 "assignee": person_id,
                 "kind": "tracker:taskTypes:Issue",
                 "component": None,
                 "milestone": None,
-                "number": 0,
+                "number": number,
                 "estimation": 0,
                 "remainingTime": 0,
                 "reportedTime": 0,
                 "reports": 0,
                 "relations": [],
+                "identifier": identifier_value,
+                "attachedTo": "tracker:ids:NoParent",
                 "parents": [],
                 "childInfo": [],
                 "dueDate": None,
-                "rank": "",
+                "rank": rank,
                 "comments": 0,
                 "subIssues": 0,
                 "labels": 0,
-                "attachedTo": "tracker:ids:NoParent",
-                "attachedToClass": "tracker:class:Issue",
-                "collection": "subIssues",
             },
-            "modifiedBy": auth.account_id,
-            "modifiedOn": int(time.time() * 1000),
         }
 
         await client.tx(transaction)
-
-        # Set description if provided (requires issue to exist first so it has a blob ref)
-        if description:
-            # Re-fetch the created issue to get its blob ref
-            created = await client.find_all(
-                "tracker:class:Issue", {"_id": new_id}, options={"limit": 1}
-            )
-            if created and created[0].get("description"):
-                from huly_cli.markup import markdown_to_prosemirror
-
-                markup = markdown_to_prosemirror(description)
-                ok = await client.set_description(new_id, created[0]["description"], markup)
-                if not ok:
-                    print_warning("Issue created but description could not be set.")
-
-        return f"Issue created in project {project} (id: {new_id})"
+        return (
+            f"Issue {identifier_value} created in project {project_doc.identifier} (id: {new_id})"
+        )
 
 
 @app.command("update")
@@ -393,13 +505,7 @@ async def _update_impl(
 ) -> None:
     auth = await ensure_auth(config)
     async with HulyClient(config, auth) as client:
-        # Find existing issue by identifier (normalise to uppercase, e.g. "roa-1" → "ROA-1")
-        issues = await client.find_all("tracker:class:Issue", {"identifier": identifier.upper()})
-        if not issues:
-            raise NotFoundError(f"Issue '{identifier}' not found.")
-        issue = issues[0]
-        issue_id: str = issue["_id"]
-        issue_space: str = issue.get("space", "")
+        issue = await _find_issue_by_identifier_or_id(client, identifier)
 
         operations: dict = {}
 
@@ -407,43 +513,16 @@ async def _update_impl(
             operations["title"] = title
 
         if status is not None:
-            status_key = status.lower().replace(" ", "-")
-            status_id = STATUS_IDS.get(status_key)
-            if status_id is None:
-                raise NotFoundError(
-                    f"Unknown status '{status}'. Valid values: {', '.join(STATUS_IDS.keys())}"
-                )
-            operations["status"] = status_id
+            operations["status"] = await _resolve_issue_status_id(client, status)
 
         if priority is not None:
-            try:
-                priority_int = int(priority)
-            except ValueError:
-                priority_int = PRIORITY_FROM_NAME.get(priority.lower())
-                if priority_int is None:
-                    raise NotFoundError(
-                        f"Unknown priority '{priority}'. Valid values: {', '.join(PRIORITY_FROM_NAME.keys())}"
-                    ) from None
-            operations["priority"] = priority_int
+            operations["priority"] = _resolve_priority_value(priority)
 
         if assignee is not None:
             if assignee == "":
-                # Unassign
                 operations["assignee"] = None
             else:
-                persons = await client.find_all("contact:class:Person")
-                query_lower = assignee.lower()
-                match = None
-                for p in persons:
-                    name: str = p.get("name", "")
-                    parts = name.split(",", 1)
-                    display = f"{parts[1].strip()} {parts[0].strip()}" if len(parts) == 2 else name
-                    if query_lower in display.lower() or query_lower in name.lower():
-                        match = p
-                        break
-                if match is None:
-                    raise NotFoundError(f"Person '{assignee}' not found.")
-                operations["assignee"] = match["_id"]
+                operations["assignee"] = await _resolve_person_by_name(client, assignee)
 
         if not operations:
             print_warning(
@@ -454,11 +533,9 @@ async def _update_impl(
         transaction = {
             "_class": "core:class:TxUpdateDoc",
             "objectClass": "tracker:class:Issue",
-            "objectSpace": issue_space,
-            "objectId": issue_id,
+            "objectSpace": issue.space,
+            "objectId": issue.id,
             "operations": operations,
-            "modifiedBy": auth.account_id,
-            "modifiedOn": int(time.time() * 1000),
         }
 
         await client.tx(transaction)
@@ -512,23 +589,27 @@ def issues_describe(
 
             auth = await ensure_auth(config)
             async with HulyClient(config, auth) as client:
-                raw_docs = await client.find_all(
-                    "tracker:class:Issue",
-                    query={"identifier": identifier.upper()},
-                    options={"limit": 1},
-                )
-                if not raw_docs:
-                    raise NotFoundError(f"Issue '{identifier}' not found.")
-                issue = Issue.model_validate(raw_docs[0])
-                if not issue.description:
-                    raise HulyError(
-                        f"Issue '{identifier}' has no description blob ref. "
-                        "Cannot update a description that was never created."
-                    )
                 markup = markdown_to_prosemirror(markdown_content or "")
-                ok = await client.set_description(issue.id, issue.description, markup)
-                if not ok:
-                    raise HulyError("Failed to update description via Collaborator RPC.")
+                issue = await _find_issue_by_identifier_or_id(client, identifier)
+                if issue.description:
+                    ok = await client.set_description(issue.id, issue.description, markup)
+                    if not ok:
+                        raise HulyError("Failed to update description via Collaborator RPC.")
+                else:
+                    blob_ref = await client.create_description(issue.id, markup)
+                    if not blob_ref:
+                        raise HulyError(
+                            "Failed to create description content via Collaborator RPC."
+                        )
+                    await client.tx(
+                        {
+                            "_class": "core:class:TxUpdateDoc",
+                            "objectClass": "tracker:class:Issue",
+                            "objectSpace": issue.space,
+                            "objectId": issue.id,
+                            "operations": {"description": blob_ref},
+                        }
+                    )
             return issue.identifier or identifier
 
         try:
@@ -556,14 +637,7 @@ def issues_describe(
     async def _run() -> tuple[str, str | None]:
         auth = await ensure_auth(config)
         async with HulyClient(config, auth) as client:
-            raw_docs = await client.find_all(
-                "tracker:class:Issue",
-                query={"identifier": identifier.upper()},
-                options={"limit": 1},
-            )
-            if not raw_docs:
-                raise NotFoundError(f"Issue '{identifier}' not found.")
-            issue = Issue.model_validate(raw_docs[0])
+            issue = await _find_issue_by_identifier_or_id(client, identifier)
             if not issue.description:
                 return issue.identifier or identifier, None
             content = await client.get_description(issue.id, issue.description)

--- a/src/huly_cli/issue_utils.py
+++ b/src/huly_cli/issue_utils.py
@@ -1,0 +1,215 @@
+"""Issue-specific helpers for status lookup and rank generation."""
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import Any
+
+from huly_cli.models import STATUS_IDS, STATUS_NAMES
+
+ISSUE_STATUS_CLASS = "tracker:class:IssueStatus"
+STATUS_CATEGORY_CLASS = "core:class:StatusCategory"
+RANK_FALLBACK = "0|hzzzzz:"
+
+_STATUS_RE = re.compile(r"^(?P<bucket>[^|]+)\|(?P<body>[0-9a-z]+):(?P<suffix>.*)$")
+_NON_ALNUM_RE = re.compile(r"[^0-9A-Za-z]+")
+_CAMEL_RE_1 = re.compile(r"([a-z0-9])([A-Z])")
+_CAMEL_RE_2 = re.compile(r"([A-Z]+)([A-Z][a-z])")
+_ALPHABET = "0123456789abcdefghijklmnopqrstuvwxyz"
+
+
+def normalize_status_key(value: str) -> str:
+    """Normalize a status/category name or identifier into a stable slug."""
+    text = value.strip()
+    text = _CAMEL_RE_1.sub(r"\1-\2", text)
+    text = _CAMEL_RE_2.sub(r"\1-\2", text)
+    text = text.replace("_", "-")
+    text = _NON_ALNUM_RE.sub("-", text)
+    text = re.sub(r"-+", "-", text).strip("-").lower()
+    return "todo" if text == "to-do" else text
+
+
+def _dedupe(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for value in values:
+        if value not in seen:
+            seen.add(value)
+            ordered.append(value)
+    return ordered
+
+
+def _normalize_label(value: str) -> str:
+    label = normalize_status_key(value)
+    return label or value
+
+
+def _increment_rank_body(body: str) -> str:
+    digits = list(body)
+    idx = len(digits) - 1
+    carry = 1
+    while idx >= 0 and carry:
+        current = _ALPHABET.index(digits[idx]) if digits[idx] in _ALPHABET else 0
+        current += carry
+        digits[idx] = _ALPHABET[current % 36]
+        carry = current // 36
+        idx -= 1
+    if carry:
+        digits.insert(0, "1")
+    return "".join(digits)
+
+
+@dataclass(slots=True)
+class IssueStatusIndex:
+    """Live issue-status lookup data."""
+
+    by_id: dict[str, dict[str, Any]] = field(default_factory=dict)
+    ids_by_name: dict[str, list[str]] = field(default_factory=dict)
+    ids_by_category_name: dict[str, list[str]] = field(default_factory=dict)
+    labels_by_id: dict[str, str] = field(default_factory=dict)
+
+    def resolve_ids(self, raw_status: str) -> list[str]:
+        """Return live status ids that match a name, category name, or raw ref."""
+        raw_key = normalize_status_key(raw_status)
+        tail_key = normalize_status_key(raw_status.rsplit(":", 1)[-1])
+
+        candidates: list[str] = []
+        if raw_status in self.by_id:
+            candidates.append(raw_status)
+
+        for key in (raw_key, tail_key):
+            candidates.extend(self.ids_by_name.get(key, []))
+            candidates.extend(self.ids_by_category_name.get(key, []))
+            fallback = STATUS_IDS.get(key)
+            if fallback:
+                candidates.append(fallback)
+
+        return _dedupe(candidates)
+
+    def label_for(self, status_id: str) -> str:
+        """Return a readable label for a status id."""
+        if status_id in STATUS_NAMES:
+            return STATUS_NAMES[status_id]
+
+        if status_id in self.labels_by_id:
+            return self.labels_by_id[status_id]
+
+        status_doc = self.by_id.get(status_id)
+        if status_doc is not None:
+            name = str(status_doc.get("name") or status_id.rsplit(":", 1)[-1])
+            return _normalize_label(name)
+
+        return _normalize_label(status_id.rsplit(":", 1)[-1] if ":" in status_id else status_id)
+
+    def available_labels(self) -> list[str]:
+        labels = {
+            *self.labels_by_id.values(),
+            *self.ids_by_name.keys(),
+            *self.ids_by_category_name.keys(),
+            *STATUS_IDS.keys(),
+        }
+        return sorted(labels)
+
+
+async def load_issue_status_index(client: Any) -> IssueStatusIndex:
+    """Load live issue statuses and their category defaults."""
+    category_rows = await client.find_all(STATUS_CATEGORY_CLASS, options={"limit": 500})
+    category_labels_by_id: dict[str, str] = {}
+    for row in category_rows:
+        category_id = row.get("_id")
+        if not category_id:
+            continue
+        category_label = str(row.get("defaultStatusName") or row.get("name") or category_id)
+        category_labels_by_id[category_id] = _normalize_label(category_label)
+
+    status_rows = await client.find_all(ISSUE_STATUS_CLASS, options={"limit": 500})
+
+    by_id: dict[str, dict[str, Any]] = {}
+    ids_by_name: dict[str, list[str]] = defaultdict(list)
+    ids_by_category_name: dict[str, list[str]] = defaultdict(list)
+    labels_by_id: dict[str, str] = {}
+
+    for row in status_rows:
+        status_id = row.get("_id")
+        if not status_id:
+            continue
+
+        by_id[status_id] = row
+        status_label = _normalize_label(str(row.get("name") or status_id.rsplit(":", 1)[-1]))
+        labels_by_id[status_id] = status_label
+        ids_by_name[status_label].append(status_id)
+
+        category_id = row.get("category")
+        if category_id:
+            category_label = category_labels_by_id.get(category_id)
+            if category_label:
+                ids_by_category_name[category_label].append(status_id)
+
+    return IssueStatusIndex(
+        by_id=by_id,
+        ids_by_name={k: _dedupe(v) for k, v in ids_by_name.items()},
+        ids_by_category_name={k: _dedupe(v) for k, v in ids_by_category_name.items()},
+        labels_by_id=labels_by_id,
+    )
+
+
+def resolve_status_ids(
+    raw_status: str,
+    status_index: IssueStatusIndex | None = None,
+    *,
+    prefer_live: bool = True,
+) -> list[str]:
+    """Resolve a human status input to one or more status ids."""
+    candidates: list[str] = []
+    if status_index is not None and prefer_live:
+        candidates.extend(status_index.resolve_ids(raw_status))
+
+    hardcoded = STATUS_IDS.get(normalize_status_key(raw_status))
+    if hardcoded:
+        candidates.append(hardcoded)
+
+    tail_hardcoded = STATUS_IDS.get(normalize_status_key(raw_status.rsplit(":", 1)[-1]))
+    if tail_hardcoded:
+        candidates.append(tail_hardcoded)
+
+    if status_index is not None and not prefer_live:
+        candidates.extend(status_index.resolve_ids(raw_status))
+
+    return _dedupe(candidates)
+
+
+def resolve_status_id(
+    raw_status: str,
+    status_index: IssueStatusIndex | None = None,
+    *,
+    preferred: str | None = None,
+) -> str:
+    """Resolve a human status input to a single status id."""
+    candidates = resolve_status_ids(raw_status, status_index)
+    if not candidates:
+        raise ValueError(raw_status)
+
+    if preferred and preferred in candidates:
+        return preferred
+    return candidates[0]
+
+
+def status_label(status_id: str, status_index: IssueStatusIndex | None = None) -> str:
+    """Return a readable label for a status id, using the live index if needed."""
+    if status_id in STATUS_NAMES:
+        return STATUS_NAMES[status_id]
+    if status_index is not None:
+        return status_index.label_for(status_id)
+    return _normalize_label(status_id.rsplit(":", 1)[-1] if ":" in status_id else status_id)
+
+
+def next_rank(previous_rank: str | None) -> str:
+    """Generate the next lexorank-like value after ``previous_rank``."""
+    if previous_rank:
+        match = _STATUS_RE.fullmatch(previous_rank)
+        if match:
+            body = _increment_rank_body(match.group("body"))
+            return f"{match.group('bucket')}|{body}:{match.group('suffix')}"
+    return RANK_FALLBACK

--- a/src/huly_cli/models.py
+++ b/src/huly_cli/models.py
@@ -55,7 +55,7 @@ class Issue(BaseModel):
     modified_by: str = Field("", alias="modifiedBy")
     modified_on: int = Field(0, alias="modifiedOn")
     estimation: int = 0
-    labels: int = 0
+    labels: Any = 0
     comments: int = 0
     sub_issues: int = Field(0, alias="subIssues")
     space: str = ""
@@ -139,11 +139,11 @@ class Document(BaseModel):
 
     id: str = Field(alias="_id")
     title: str = ""
-    content: str = ""  # blob ref (empty string if no content yet)
+    content: str | None = ""  # blob ref (empty string or null if no content yet)
     space: str = ""
     parent: str = Field("", alias="parent")
     attachments: int = 0
-    labels: int = 0
+    labels: Any = 0
     comments: int = 0
     rank: str = ""
     created_by: str = Field("", alias="createdBy")
@@ -234,7 +234,7 @@ class IssueTemplate(BaseModel):
     children: list[Any] = []
     comments: int = 0
     attachments: int = 0
-    labels: int = 0
+    labels: Any = 0
     kind: str = ""
     relations: list[Any] = []
     space: str = ""

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -179,6 +179,20 @@ async def test_get_description(fake_config, fake_auth):
     assert parsed["type"] == "doc"
 
 
+async def test_create_description(fake_config, fake_auth):
+    doc_id = urllib.parse.quote("uuid-test-456|tracker:class:Issue|issue1|description", safe="")
+    with respx.mock:
+        route = respx.post(f"https://test.example.com/_collaborator/rpc/{doc_id}").respond(
+            json={"content": {"description": "blob-ref-456"}}
+        )
+        async with HulyClient(fake_config, fake_auth) as client:
+            result = await client.create_description("issue1", '{"type":"doc","content":[]}')
+    assert result == "blob-ref-456"
+    body = json.loads(route.calls[0].request.content)
+    assert body["method"] == "createContent"
+    assert "description" in body["payload"]["content"]
+
+
 async def test_set_description(fake_config, fake_auth):
     doc_id = urllib.parse.quote("uuid-test-456|tracker:class:Issue|issue1|description", safe="")
     with respx.mock:

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from contextlib import ExitStack, contextmanager
 from unittest.mock import AsyncMock, patch
 
 from typer.testing import CliRunner
@@ -23,9 +24,20 @@ FAKE_AUTH = AuthCache(
 )
 
 
+@contextmanager
 def _auth_patch():
-    """Patch ensure_auth to return FAKE_AUTH directly (used by all sub-commands)."""
-    return patch("huly_cli.auth.ensure_auth", new=AsyncMock(return_value=FAKE_AUTH))
+    """Patch every command module that imported ensure_auth directly."""
+    auth_mock = AsyncMock(return_value=FAKE_AUTH)
+    modules = [
+        "huly_cli.auth",
+        "huly_cli.commands.issues",
+        "huly_cli.commands.documents",
+        "huly_cli.commands.components",
+    ]
+    with ExitStack() as stack:
+        for module in modules:
+            stack.enter_context(patch(f"{module}.ensure_auth", new=auth_mock))
+        yield auth_mock
 
 
 # ── projects list ──────────────────────────────────────────────────────────────

--- a/tests/test_commands_new.py
+++ b/tests/test_commands_new.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from contextlib import ExitStack, contextmanager
 from unittest.mock import AsyncMock, patch
 
 from typer.testing import CliRunner
@@ -23,9 +24,19 @@ FAKE_AUTH = AuthCache(
 )
 
 
+@contextmanager
 def _auth_patch():
-    """Patch ensure_auth to return FAKE_AUTH directly (used by all sub-commands)."""
-    return patch("huly_cli.auth.ensure_auth", new=AsyncMock(return_value=FAKE_AUTH))
+    """Patch every command module that imported ensure_auth directly."""
+    auth_mock = AsyncMock(return_value=FAKE_AUTH)
+    modules = [
+        "huly_cli.auth",
+        "huly_cli.commands.milestones",
+        "huly_cli.commands.templates",
+    ]
+    with ExitStack() as stack:
+        for module in modules:
+            stack.enter_context(patch(f"{module}.ensure_auth", new=auth_mock))
+        yield auth_mock
 
 
 # ── milestones list ────────────────────────────────────────────────────────────

--- a/tests/test_issue_write_path.py
+++ b/tests/test_issue_write_path.py
@@ -1,0 +1,237 @@
+"""Regression tests for issue write-path compatibility with live Huly semantics."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+from typer.testing import CliRunner
+
+from huly_cli.commands import issues as issues_cmd
+from huly_cli.issue_utils import IssueStatusIndex
+from huly_cli.main import app
+from huly_cli.models import Issue
+
+runner = CliRunner()
+
+
+def _raw_issue(**overrides: object) -> dict[str, object]:
+    issue: dict[str, object] = {
+        "_id": "issue-1",
+        "title": "Existing issue",
+        "identifier": "ROA-1",
+        "number": 1,
+        "status": "tracker:status:Backlog",
+        "priority": 2,
+        "assignee": None,
+        "description": "",
+        "kind": "tracker:taskTypes:Issue",
+        "createdBy": "",
+        "createdOn": 0,
+        "modifiedBy": "",
+        "modifiedOn": 0,
+        "estimation": 0,
+        "labels": 0,
+        "comments": 0,
+        "subIssues": 0,
+        "space": "project-1",
+        "dueDate": None,
+    }
+    issue.update(overrides)
+    return issue
+
+
+async def test_find_issue_by_identifier_or_id_falls_back_to_internal_id():
+    client = AsyncMock()
+    client.find_all = AsyncMock(
+        side_effect=[[], [_raw_issue(identifier="", _id="69d30187cac655019948a821")]]
+    )
+
+    issue = await issues_cmd._find_issue_by_identifier_or_id(client, "69d30187cac655019948a821")
+
+    assert issue.id == "69d30187cac655019948a821"
+    assert client.find_all.await_args_list[1].kwargs["query"] == {"_id": "69d30187cac655019948a821"}
+
+
+async def test_create_impl_increments_project_sequence_and_uses_blob_ref(fake_config, fake_auth):
+    project_doc = {
+        "_id": "project-1",
+        "name": "Roadmap",
+        "identifier": "ROA",
+        "sequence": 16,
+        "members": [],
+        "owners": [],
+        "description": "",
+        "defaultIssueStatus": "tracker:status:Backlog",
+        "private": False,
+        "archived": False,
+    }
+    find_all_mock = AsyncMock(
+        side_effect=[
+            [project_doc],
+            [{"_id": "issue-16", "rank": "0|i0002f:", "space": "project-1"}],
+        ]
+    )
+    tx_mock = AsyncMock(side_effect=[{"object": {"sequence": 17}}, {}])
+    create_description_mock = AsyncMock(return_value="blob-description-1")
+
+    with (
+        patch("huly_cli.commands.issues.ensure_auth", new=AsyncMock(return_value=fake_auth)),
+        patch("huly_cli.client.HulyClient.find_all", find_all_mock),
+        patch("huly_cli.client.HulyClient.tx", tx_mock),
+        patch("huly_cli.client.HulyClient.create_description", create_description_mock),
+    ):
+        message = await issues_cmd._create_impl(
+            fake_config,
+            title="Fix auth drift",
+            project="ROA",
+            status=None,
+            priority="high",
+            assignee=None,
+            description="# Heading",
+        )
+
+    increment_tx = tx_mock.await_args_list[0].args[0]
+    create_tx = tx_mock.await_args_list[1].args[0]
+
+    assert increment_tx["objectClass"] == "tracker:class:Project"
+    assert increment_tx["objectId"] == "project-1"
+    assert increment_tx["operations"] == {"$inc": {"sequence": 1}}
+    assert increment_tx["retrieve"] is True
+
+    assert create_tx["objectClass"] == "tracker:class:Issue"
+    assert create_tx["objectSpace"] == "project-1"
+    assert create_tx["attributes"]["number"] == 17
+    assert create_tx["attributes"]["identifier"] == "ROA-17"
+    assert create_tx["attributes"]["rank"] == "0|i0002g:"
+    assert create_tx["attributes"]["description"] == "blob-description-1"
+    assert create_tx["attributes"]["status"] == "tracker:status:Backlog"
+    assert create_tx["attributes"]["priority"] == 2
+    assert "ROA-17" in message
+    create_description_mock.assert_awaited_once()
+
+
+async def test_update_impl_resolves_custom_status_and_unassigns(fake_config, fake_auth):
+    issue = Issue.model_validate(_raw_issue(space="project-1"))
+    tx_mock = AsyncMock(return_value={})
+
+    with (
+        patch("huly_cli.commands.issues.ensure_auth", new=AsyncMock(return_value=fake_auth)),
+        patch(
+            "huly_cli.commands.issues._find_issue_by_identifier_or_id",
+            new=AsyncMock(return_value=issue),
+        ),
+        patch(
+            "huly_cli.commands.issues._resolve_issue_status_id",
+            new=AsyncMock(return_value="69d4da9e2afab311abc0e8f7"),
+        ),
+        patch("huly_cli.client.HulyClient.tx", tx_mock),
+    ):
+        await issues_cmd._update_impl(
+            fake_config,
+            identifier="ROA-1",
+            title="Updated title",
+            status="UAT",
+            priority="high",
+            assignee="",
+        )
+
+    update_tx = tx_mock.await_args.args[0]
+    assert update_tx["objectClass"] == "tracker:class:Issue"
+    assert update_tx["objectSpace"] == "project-1"
+    assert update_tx["objectId"] == "issue-1"
+    assert update_tx["operations"] == {
+        "title": "Updated title",
+        "status": "69d4da9e2afab311abc0e8f7",
+        "priority": 2,
+        "assignee": None,
+    }
+
+
+def test_issues_describe_set_creates_blob_ref_when_missing(fake_auth):
+    tx_mock = AsyncMock(return_value={})
+    create_description_mock = AsyncMock(return_value="blob-description-2")
+
+    with (
+        patch("huly_cli.commands.issues.ensure_auth", new=AsyncMock(return_value=fake_auth)),
+        patch(
+            "huly_cli.client.HulyClient.find_all",
+            new=AsyncMock(return_value=[_raw_issue(description=None)]),
+        ),
+        patch("huly_cli.client.HulyClient.create_description", create_description_mock),
+        patch("huly_cli.client.HulyClient.tx", tx_mock),
+    ):
+        result = runner.invoke(app, ["issues", "describe", "ROA-1", "--set", "hello world"])
+
+    assert result.exit_code == 0, result.output
+    assert "Description updated for ROA-1." in result.output
+    assert tx_mock.await_args.args[0]["operations"] == {"description": "blob-description-2"}
+
+
+def test_issues_get_formats_workspace_specific_status(fake_auth):
+    captured: dict[str, object] = {}
+
+    def capture(data: dict[str, object], title: str) -> None:
+        captured["data"] = data
+        captured["title"] = title
+
+    with (
+        patch("huly_cli.commands.issues.ensure_auth", new=AsyncMock(return_value=fake_auth)),
+        patch(
+            "huly_cli.client.HulyClient.find_all",
+            new=AsyncMock(
+                side_effect=[
+                    [_raw_issue(status="69d4da9e2afab311abc0e8f7")],
+                    [],
+                    [{"_id": "cat-1", "defaultStatusName": "UAT"}],
+                    [{"_id": "69d4da9e2afab311abc0e8f7", "name": "UAT", "category": "cat-1"}],
+                ]
+            ),
+        ),
+        patch("huly_cli.commands.issues.print_item", side_effect=capture),
+    ):
+        result = runner.invoke(app, ["issues", "get", "ROA-1"])
+
+    assert result.exit_code == 0, result.output
+    assert captured["data"]["status"] == "uat"
+    assert captured["data"]["status_id"] == "69d4da9e2afab311abc0e8f7"
+
+
+def test_issues_list_fans_out_multi_status_queries(fake_auth):
+    captured: dict[str, object] = {}
+    find_all_mock = AsyncMock(
+        side_effect=[
+            [_raw_issue(_id="issue-1", identifier="ROA-1", status="status-1")],
+            [_raw_issue(_id="issue-2", identifier="ROA-2", status="status-2")],
+            [],
+        ]
+    )
+    status_index = IssueStatusIndex(
+        labels_by_id={"status-1": "ready", "status-2": "ready"},
+        by_id={"status-1": {"name": "Ready"}, "status-2": {"name": "Ready"}},
+    )
+
+    def capture(items: list[dict[str, object]], columns: list[str], title: str) -> None:
+        captured["items"] = items
+        captured["columns"] = columns
+        captured["title"] = title
+
+    with (
+        patch("huly_cli.commands.issues.ensure_auth", new=AsyncMock(return_value=fake_auth)),
+        patch(
+            "huly_cli.commands.issues.load_issue_status_index",
+            new=AsyncMock(return_value=status_index),
+        ),
+        patch(
+            "huly_cli.commands.issues.resolve_status_ids",
+            side_effect=[[], ["status-1", "status-2"]],
+        ),
+        patch("huly_cli.client.HulyClient.find_all", find_all_mock),
+        patch("huly_cli.commands.issues.print_list", side_effect=capture),
+    ):
+        result = runner.invoke(app, ["issues", "list", "--status", "ready", "--limit", "10"])
+
+    assert result.exit_code == 0, result.output
+    assert find_all_mock.await_args_list[0].kwargs["query"] == {"status": "status-1"}
+    assert find_all_mock.await_args_list[1].kwargs["query"] == {"status": "status-2"}
+    assert [item["identifier"] for item in captured["items"]] == ["ROA-1", "ROA-2"]
+    assert [item["status"] for item in captured["items"]] == ["ready", "ready"]

--- a/tests/test_read_path_compat.py
+++ b/tests/test_read_path_compat.py
@@ -1,0 +1,226 @@
+"""Compatibility tests for read-path normalization and model shapes."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import respx
+from typer.testing import CliRunner
+
+from huly_cli.client import HulyClient
+from huly_cli.main import app
+from huly_cli.models import Document, IssueTemplate
+
+runner = CliRunner()
+
+
+async def test_find_all_normalizes_scalar_query_values_and_lookup_map(fake_config, fake_auth):
+    response = {
+        "value": [
+            {
+                "title": "Bug report",
+                "$lookup": {
+                    "assignee": "person-1",
+                    "reviewers": ["person-1", "person-2"],
+                },
+            }
+        ],
+        "lookupMap": {
+            "person-1": {"_id": "person-1", "name": "Doe,John"},
+            "person-2": {"_id": "person-2", "name": "Smith,Jane"},
+        },
+        "total": 1,
+    }
+    with respx.mock:
+        respx.post("https://test.example.com/_transactor/api/v1/find-all/w-test-123").respond(
+            json=response
+        )
+        async with HulyClient(fake_config, fake_auth) as client:
+            result = await client.find_all(
+                "tracker:class:Issue",
+                query={"_id": "issue-1", "identifier": "ROA-1"},
+            )
+
+    assert result[0]["_class"] == "tracker:class:Issue"
+    assert result[0]["_id"] == "issue-1"
+    assert result[0]["identifier"] == "ROA-1"
+    assert result[0]["$lookup"]["assignee"] == {"_id": "person-1", "name": "Doe,John"}
+    assert result[0]["$lookup"]["reviewers"] == [
+        {"_id": "person-1", "name": "Doe,John"},
+        {"_id": "person-2", "name": "Smith,Jane"},
+    ]
+
+
+def test_document_model_accepts_null_content():
+    doc = Document.model_validate({"_id": "doc-1", "title": "Doc", "content": None})
+    assert doc.content is None
+
+
+def test_issue_template_model_accepts_list_labels():
+    template = IssueTemplate.model_validate(
+        {
+            "_id": "tmpl-1",
+            "title": "Template",
+            "labels": [{"_id": "label-1", "title": "Bug"}],
+        }
+    )
+    assert template.labels == [{"_id": "label-1", "title": "Bug"}]
+
+
+def test_documents_get_handles_null_content_and_restored_id(fake_auth):
+    captured: dict[str, object] = {}
+
+    def capture(data: dict[str, object], title: str) -> None:
+        captured["data"] = data
+        captured["title"] = title
+
+    response = {
+        "value": [
+            {
+                "title": "Doc Zero",
+                "content": None,
+                "space": "space-1",
+                "labels": [{"_id": "label-1", "title": "Bug"}],
+                "comments": 0,
+                "attachments": 0,
+                "rank": "",
+                "createdBy": "user-1",
+                "createdOn": 1,
+                "modifiedBy": "user-1",
+                "modifiedOn": 2,
+            }
+        ],
+        "total": 1,
+    }
+
+    with (
+        respx.mock,
+        patch("huly_cli.commands.documents.ensure_auth", new=AsyncMock(return_value=fake_auth)),
+        patch("huly_cli.commands.documents._fetch_teamspace_map", new=AsyncMock(return_value={})),
+        patch("huly_cli.commands.documents.print_item", side_effect=capture),
+    ):
+        respx.post("https://test.example.com/_transactor/api/v1/find-all/w-test-123").respond(
+            json=response
+        )
+        result = runner.invoke(
+            app,
+            [
+                "--url",
+                "https://test.example.com",
+                "--workspace",
+                "test-ws",
+                "documents",
+                "get",
+                "doc-1",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert captured["data"]["id"] == "doc-1"
+    assert captured["data"]["content_ref"] is None
+    assert captured["data"]["labels"] == [{"_id": "label-1", "title": "Bug"}]
+
+
+def test_templates_get_handles_list_labels_and_restored_id(fake_auth):
+    captured: dict[str, object] = {}
+
+    def capture(data: dict[str, object], title: str) -> None:
+        captured["data"] = data
+        captured["title"] = title
+
+    response = {
+        "value": [
+            {
+                "title": "Bug Report",
+                "description": "",
+                "assignee": None,
+                "component": None,
+                "milestone": None,
+                "priority": 1,
+                "estimation": 0,
+                "children": [],
+                "comments": 0,
+                "attachments": 0,
+                "labels": [{"_id": "label-1", "title": "Bug"}],
+                "kind": "",
+                "relations": [],
+                "space": "space-1",
+            }
+        ],
+        "total": 1,
+    }
+
+    with (
+        respx.mock,
+        patch("huly_cli.commands.templates.ensure_auth", new=AsyncMock(return_value=fake_auth)),
+        patch("huly_cli.commands.templates.print_item", side_effect=capture),
+    ):
+        respx.post("https://test.example.com/_transactor/api/v1/find-all/w-test-123").respond(
+            json=response
+        )
+        result = runner.invoke(
+            app,
+            [
+                "--url",
+                "https://test.example.com",
+                "--workspace",
+                "test-ws",
+                "templates",
+                "get",
+                "tmpl-1",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert captured["data"]["id"] == "tmpl-1"
+    assert captured["data"]["labels"] == [{"_id": "label-1", "title": "Bug"}]
+
+
+def test_components_get_handles_filtered_find_all_response(fake_auth):
+    captured: dict[str, object] = {}
+
+    def capture(data: dict[str, object], title: str) -> None:
+        captured["data"] = data
+        captured["title"] = title
+
+    response = {
+        "value": [
+            {
+                "label": "Core",
+                "description": "Core component",
+                "lead": None,
+                "space": "project-1",
+                "createdBy": "user-1",
+                "createdOn": 1,
+                "modifiedBy": "user-1",
+                "modifiedOn": 2,
+            }
+        ],
+        "total": 1,
+    }
+
+    with (
+        respx.mock,
+        patch("huly_cli.commands.components.ensure_auth", new=AsyncMock(return_value=fake_auth)),
+        patch("huly_cli.commands.components._fetch_person_map", new=AsyncMock(return_value={})),
+        patch("huly_cli.commands.components.print_item", side_effect=capture),
+    ):
+        respx.post("https://test.example.com/_transactor/api/v1/find-all/w-test-123").respond(
+            json=response
+        )
+        result = runner.invoke(
+            app,
+            [
+                "--url",
+                "https://test.example.com",
+                "--workspace",
+                "test-ws",
+                "components",
+                "get",
+                "comp-1",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert captured["data"]["id"] == "comp-1"
+    assert captured["data"]["label"] == "Core"


### PR DESCRIPTION
## Summary
- patch the CI-auth test isolation issue that broke GitHub Actions without a local auth cache
- normalize read-path responses and relax model assumptions to match live `v0.6.504` workspace data
- align issue commands with live workspace status metadata and upstream sequence/rank behavior
- add setup, login, and smoke-test documentation plus `.env.example`

## Validation
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest tests/ -q`
- live read-only smoke tests against `https://huly.ingenuity.ph` workspace `efs`

## Notes
- live write commands were not executed against the shared workspace
- branch history is linear and contains no merge commits over `master`