### PR TITLE
Add Huly CLI agent skill and install docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+# Repo Notes
+
+For tasks involving installation, authentication, smoke testing, or operation of
+`huly-cli`, use the repo-local skill at `skills/huly-cli`.
+
+Key facts:
+
+- PyPI package name: `huly-cli`
+- Executable name: `huly`
+- In this repo, prefer `uv run huly ...`
+- For live validation, use `scripts/live_smoke.py`
+- Workspace slug and project identifier are different concepts

--- a/README.md
+++ b/README.md
@@ -51,7 +51,28 @@ If you run `huly issues list --project EFS`, it will fail because `EFS` is not a
 - [`uv`](https://docs.astral.sh/uv/)
 - A Huly account with access to the target workspace
 
-## Setup
+## Install
+
+### Option 1: Install from PyPI
+
+Use this if you only want the CLI and are not modifying the source:
+
+```bash
+pip install huly-cli
+huly --help
+```
+
+Upgrade an existing install:
+
+```bash
+pip install --upgrade huly-cli
+```
+
+The package name is `huly-cli`. The executable is `huly`.
+
+### Option 2: Use from a source checkout
+
+Use this if you are developing in this repository:
 
 1. Install dependencies, including dev tools:
 
@@ -101,6 +122,8 @@ The token cache is reused automatically. If the cached token expires, the CLI ne
 
 ## Login Walkthrough
 
+If you installed from PyPI, replace `uv run huly` below with `huly`.
+
 ### Option 1: Interactive login
 
 This is the simplest flow if you are testing locally and do not want to keep your password
@@ -138,6 +161,29 @@ Then run:
 ```bash
 uv run huly auth login
 uv run huly auth status
+```
+
+## Agent Skill
+
+This repo includes a Codex skill for agents that need to install or operate the
+CLI:
+
+- skill path: `skills/huly-cli`
+- explicit invocation: `$huly-cli`
+
+If you want to install that skill into a Codex skills directory outside this
+repo, copy or symlink it into `${CODEX_HOME:-$HOME/.codex}/skills`:
+
+```bash
+mkdir -p "${CODEX_HOME:-$HOME/.codex}/skills"
+ln -s "$(pwd)/skills/huly-cli" "${CODEX_HOME:-$HOME/.codex}/skills/huly-cli"
+```
+
+If you prefer a copy instead of a symlink:
+
+```bash
+mkdir -p "${CODEX_HOME:-$HOME/.codex}/skills"
+cp -R skills/huly-cli "${CODEX_HOME:-$HOME/.codex}/skills/"
 ```
 
 ## Hands-On Smoke Test
@@ -264,11 +310,19 @@ Expected result at the time of verification:
 
 ## Packaging And PyPI
 
-The repo now builds a wheel and sdist cleanly and CI validates the distribution
-metadata.
+The package is published on PyPI as `huly-cli`.
 
-For the full release checklist, including the manual PyPI setup you still need
-to do, see [RELEASE.md](RELEASE.md).
+Install it with:
+
+```bash
+pip install huly-cli
+```
+
+The repo also builds a wheel and sdist cleanly and CI validates the
+distribution metadata.
+
+For the maintainer release checklist and publisher configuration notes, see
+[RELEASE.md](RELEASE.md).
 
 ## CLI Help
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,29 +3,33 @@
 This repo is set up to publish `huly-cli` to PyPI using GitHub Actions Trusted
 Publishing.
 
-## What the repo now handles
+## Current release setup
 
 - Builds a wheel and sdist with `python -m build`
 - Validates package metadata with `twine check`
 - Verifies packaging in CI
 - Includes a publish workflow at
   `.github/workflows/publish-pypi.yml`
+- Publishes the `huly-cli` package to PyPI through GitHub Actions Trusted
+  Publishing
 
-## Manual steps you still need to do once
+Key identifiers for this repo:
 
-1. Decide the final PyPI project name.
+- PyPI project name: `huly-cli`
+- Repository owner: `teslakoile`
+- Repository name: `huly-cli`
+- Workflow filename: `publish-pypi.yml`
+- GitHub environment: `pypi`
 
-The current package name is `huly-cli`. Before the first release, confirm it is
-the name you want to keep and that it is available on PyPI.
+## One-time checks
 
-2. Create and secure a PyPI account.
+These are not normal per-release tasks. Revisit them only if you change the
+repository owner, repository name, workflow filename, or environment.
 
-- Create an account at `https://pypi.org/account/register/`
-- Enable 2FA on the account
+1. Confirm Trusted Publishing still points at the correct repository and
+workflow.
 
-3. Configure Trusted Publishing on PyPI.
-
-Use PyPI's GitHub Actions Trusted Publisher flow and register this repository:
+The expected publisher configuration is:
 
 - Repository owner: `teslakoile`
 - Repository name: `huly-cli`
@@ -33,18 +37,21 @@ Use PyPI's GitHub Actions Trusted Publisher flow and register this repository:
 - GitHub environment: `pypi`
 - PyPI project name: `huly-cli`
 
-For a brand new package, create a pending publisher first. PyPI will create the
-project on first successful publish.
+2. Confirm the GitHub environment still exists and has the protection rules you
+want.
+
+Use a GitHub environment named `pypi`. If you want manual approval before every
+publish, require reviewers there.
+
+3. Keep PyPI account security in good standing.
+
+- Create an account at `https://pypi.org/account/register/`
+- Enable 2FA on the account
 
 Official references:
 
 - `https://docs.pypi.org/trusted-publishers/creating-a-project-through-oidc/`
 - `https://docs.pypi.org/trusted-publishers/using-a-publisher/`
-
-4. Add environment protection in GitHub.
-
-Create a GitHub environment named `pypi` and, if you want approval before every
-publish, require reviewers there.
 
 ## Manual steps for each release
 

--- a/skills/huly-cli/SKILL.md
+++ b/skills/huly-cli/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: huly-cli
+description: Use this skill when a user needs to install, configure, authenticate, smoke-test, or operate the huly-cli package from PyPI or from this repository. It covers package installation, source-checkout usage, login and env setup, validation, and the implemented command surfaces for projects, issues, documents, components, milestones, templates, members, and labels.
+---
+
+# Huly CLI
+
+## Overview
+
+This skill helps an agent get `huly-cli` working from either a PyPI install or a
+source checkout, then use the CLI safely and predictably.
+
+Use this skill for:
+
+- installing `huly-cli`
+- deciding between PyPI usage and repo-local development usage
+- configuring auth and environment variables
+- running smoke checks
+- operating the supported CLI surfaces
+
+## Workflow
+
+### 0. Detect whether the CLI is already available
+
+Check whether the executable is already present before giving install steps:
+
+```bash
+huly --help
+```
+
+Interpretation:
+
+- if `huly --help` works, the installed-package flow is available
+- if `huly` is missing but the user is inside this repository, prefer
+  `uv run huly ...`
+- if neither is available, install `huly-cli` from PyPI or set up the repo
+
+### 1. Choose the install mode
+
+If the user only wants to use the CLI, prefer the published package:
+
+```bash
+pip install huly-cli
+huly --help
+```
+
+If the user is working inside this repository or needs the unreleased source
+version, prefer the repo-local flow:
+
+```bash
+uv sync --extra dev
+uv run huly --help
+```
+
+Rule:
+
+- installed package: use `huly ...`
+- source checkout: use `uv run huly ...`
+
+Do not tell users to run `pip install huly cli`. The package name is
+`huly-cli` and the executable is `huly`.
+
+### 2. Configure authentication
+
+Required config:
+
+- `HULY_URL`
+- `HULY_WORKSPACE`
+
+Optional but useful for non-interactive login or token refresh:
+
+- `HULY_EMAIL`
+- `HULY_PASSWORD`
+
+The simplest local auth flow is:
+
+```bash
+huly auth login
+huly auth status
+```
+
+or in a repo checkout:
+
+```bash
+uv run huly auth login
+uv run huly auth status
+```
+
+Important distinction:
+
+- workspace slug and project identifier are not the same thing
+- example from this repo: workspace `efs`, project `ROA`
+
+### 3. Validate the installation
+
+Start with:
+
+```bash
+huly auth status
+huly projects list
+```
+
+If the user is in a repo checkout, use the repo-local executable instead:
+
+```bash
+uv run huly auth status
+uv run huly projects list
+```
+
+If you are in the repo, prefer the bundled smoke runner:
+
+```bash
+uv run python scripts/live_smoke.py
+```
+
+Only use write-mode smoke checks when disposable data is acceptable:
+
+```bash
+uv run python scripts/live_smoke.py --allow-writes
+```
+
+The write-mode smoke runner creates and cleans up temporary issues, documents,
+components, and milestones.
+
+### 4. Operate the CLI
+
+Prefer `--json` when an agent needs stable machine-readable output.
+
+Current implemented command groups:
+
+- `auth`
+- `projects`
+- `issues`
+- `documents`
+- `components`
+- `milestones`
+- `templates`
+- `members`
+- `labels`
+
+Current live-validated CRUD coverage:
+
+- issues: create, get, describe, update, delete
+- documents: create, get, describe, update, delete
+- components: create, get, update, delete
+- milestones: create, get, update, delete
+- templates: list, get, describe, set description
+
+### 5. Use repo facts when relevant
+
+This repo currently targets Huly platform `v0.6.504`.
+
+If operating from a clone of this repository:
+
+- main human docs: `README.md`
+- release docs: `RELEASE.md`
+- live smoke runner: `scripts/live_smoke.py`
+
+For concrete commands and a compact usage cookbook, read
+`references/usage.md`.

--- a/skills/huly-cli/agents/openai.yaml
+++ b/skills/huly-cli/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Huly CLI"
+  short_description: "Install and operate the Huly CLI"
+  default_prompt: "Use $huly-cli to detect whether the Huly CLI is installed, install it if needed, authenticate it for a workspace, and run the appropriate smoke checks."

--- a/skills/huly-cli/references/usage.md
+++ b/skills/huly-cli/references/usage.md
@@ -1,0 +1,176 @@
+# Huly CLI usage reference
+
+## Detect whether it is already installed
+
+Try the executable first:
+
+```bash
+huly --help
+```
+
+If that fails and you are inside a source checkout, use:
+
+```bash
+uv run huly --help
+```
+
+## Install modes
+
+### PyPI install
+
+Use when the user just needs the tool:
+
+```bash
+pip install huly-cli
+huly --help
+```
+
+Upgrade an existing PyPI install:
+
+```bash
+pip install --upgrade huly-cli
+```
+
+### Source checkout
+
+Use when the user is working in this repository:
+
+```bash
+uv sync --extra dev
+uv run huly --help
+```
+
+## Auth setup
+
+Required environment:
+
+```bash
+HULY_URL=https://your-huly-host
+HULY_WORKSPACE=your-workspace-slug
+```
+
+Optional for non-interactive login or automatic re-auth:
+
+```bash
+HULY_EMAIL=you@example.com
+HULY_PASSWORD=your-password
+```
+
+Interactive login:
+
+```bash
+huly auth login
+huly auth status
+```
+
+Repo-local:
+
+```bash
+uv run huly auth login
+uv run huly auth status
+```
+
+If the skill is guiding a user who installed from PyPI, prefer `huly ...`.
+If the skill is guiding a user inside this repo, prefer `uv run huly ...`.
+
+## Quick smoke checks
+
+Minimal:
+
+```bash
+huly auth status
+huly projects list
+```
+
+Repo-local read-only smoke:
+
+```bash
+uv run python scripts/live_smoke.py
+```
+
+Repo-local CRUD smoke with cleanup:
+
+```bash
+uv run python scripts/live_smoke.py --allow-writes
+```
+
+## Common command patterns
+
+### Projects
+
+```bash
+huly projects list
+huly projects get ROA
+```
+
+### Issues
+
+```bash
+huly issues list --project ROA --limit 5
+huly issues get ROA-1
+huly issues describe ROA-1
+huly issues create --project ROA --title "Example" --description "Example description"
+huly issues update ROA-1 --title "Updated title" --status done
+huly issues delete ROA-1
+```
+
+### Documents
+
+```bash
+huly documents list --limit 5
+huly documents create --space "RoA - Staff Augmentation" --title "Example Doc"
+huly documents describe DOC_ID --set "Example content"
+huly documents update DOC_ID --title "Updated title"
+huly documents delete DOC_ID
+```
+
+### Components
+
+```bash
+huly components list --project ROA --limit 5
+huly components create --project ROA --label "Example Component"
+huly components update COMPONENT_ID --label "Updated Component"
+huly components delete COMPONENT_ID
+```
+
+### Milestones
+
+```bash
+huly milestones list --project ROA --limit 5
+huly milestones create --project ROA --label "Example Milestone" --status planned
+huly milestones update MILESTONE_ID --status completed
+huly milestones delete MILESTONE_ID
+```
+
+### Templates
+
+```bash
+huly templates list --project ROA --limit 5
+huly templates get TEMPLATE_ID
+huly templates describe TEMPLATE_ID
+huly templates describe TEMPLATE_ID --set "Updated description"
+```
+
+### Members and labels
+
+```bash
+huly members list
+huly labels list
+```
+
+## Output mode
+
+Prefer JSON for agent workflows:
+
+```bash
+huly --json projects list
+huly --json issues get ROA-1
+```
+
+## Troubleshooting
+
+- Install package name: `huly-cli`
+- Executable name: `huly`
+- Workspace slug is not the same thing as a project identifier
+- If cached auth expires, ensure `HULY_EMAIL` and `HULY_PASSWORD` are available
+- In this repo, prefer `uv run huly ...` over invoking `huly` directly


### PR DESCRIPTION
## Summary
- add a repo-local Codex skill for installing, authenticating, and using huly-cli
- document PyPI install vs source-checkout usage in the README
- refresh release docs so PyPI publishing guidance matches the current setup

## Validation
- uv run --with pyyaml python /Users/kyle/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/huly-cli
- uv run ruff check .
- uv run ruff format --check .
- uv run --extra dev pytest -q
- uv run python -m build
- uv run twine check dist/*