### PR TITLE
chore: anonymize PII and auto-create GitHub releases

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # Minimal required config
-HULY_URL=https://huly.ingenuity.ph
-HULY_WORKSPACE=efs
+HULY_URL=https://huly.example.com
+HULY_WORKSPACE=my-ws
 
 # Optional for interactive local use.
 # Recommended for non-interactive runs or automatic re-auth when the cached token expires.

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -59,3 +59,15 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+
+  release:
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - name: Create GitHub Release
+        run: gh release create "${{ github.ref_name }}" --generate-notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ Python CLI for interacting with a Huly workspace from the terminal.
 This repo is currently a Python `typer` CLI, not a Node or `pnpm` project.
 
 It has been checked against `hcengineering/platform@v0.6.504` and smoke-tested against
-`https://huly.ingenuity.ph` workspace `efs`.
+`https://huly.example.com` workspace `my-ws`.
 
 What is verified today:
 
 - Authentication flow via `/_accounts`
 - Read access for projects, issues, components, documents, templates, members, labels, and issue descriptions
-- Live CRUD for issues, documents, components, and milestones on `https://huly.ingenuity.ph` workspace `efs`
+- Live CRUD for issues, documents, components, and milestones on `https://huly.example.com` workspace `my-ws`
 - Live template description update and restore flow
 - Workspace-specific issue status display and status filtering
 - Local unit/CLI test suite
@@ -36,14 +36,14 @@ Known live compatibility gaps at the time of writing:
 
 - Huly platform tag: `v0.6.504`
 - Example workspace URL used during verification:
-  `https://huly.ingenuity.ph/workbench/efs/tracker/69cb986a2df46a01935af670/issues`
+  `https://huly.example.com/workbench/my-ws/tracker/PROJECT_ID/issues`
 
 Important distinction:
 
-- `efs` is the workspace slug
-- `ROA` is the project identifier in that workspace
+- `my-ws` is the workspace slug
+- `DEMO` is the project identifier in that workspace
 
-If you run `huly issues list --project EFS`, it will fail because `EFS` is not a project ID.
+If you run `huly issues list --project MY-WS`, it will fail because `MY-WS` is not a project ID.
 
 ## Prerequisites
 
@@ -130,7 +130,7 @@ This is the simplest flow if you are testing locally and do not want to keep you
 in `.env`.
 
 ```bash
-uv run huly --url https://huly.ingenuity.ph --workspace efs auth login
+uv run huly --url https://huly.example.com --workspace my-ws auth login
 ```
 
 You will be prompted for:
@@ -150,8 +150,8 @@ uv run huly auth status
 Put all four values in `.env`:
 
 ```bash
-HULY_URL=https://huly.ingenuity.ph
-HULY_WORKSPACE=efs
+HULY_URL=https://huly.example.com
+HULY_WORKSPACE=my-ws
 HULY_EMAIL=you@example.com
 HULY_PASSWORD=your-password
 ```
@@ -217,37 +217,37 @@ uv run huly projects list
 3. Inspect the verified sample project:
 
 ```bash
-uv run huly projects get ROA
+uv run huly projects get DEMO
 ```
 
 4. List a few issues from that project:
 
 ```bash
-uv run huly issues list --project ROA --limit 5
+uv run huly issues list --project DEMO --limit 5
 ```
 
 5. Inspect one issue:
 
 ```bash
-uv run huly issues get ROA-1
+uv run huly issues get DEMO-1
 ```
 
 6. Read the issue description:
 
 ```bash
-uv run huly issues describe ROA-1
+uv run huly issues describe DEMO-1
 ```
 
 7. List project components:
 
 ```bash
-uv run huly components list --project ROA --limit 5
+uv run huly components list --project DEMO --limit 5
 ```
 
 8. Inspect a component by internal ID:
 
 ```bash
-uv run huly components get 16e202fa79377835295c79eb
+uv run huly components get COMPONENT_ID
 ```
 
 9. List a few documents:
@@ -286,7 +286,7 @@ If you want machine-readable output for quick inspection:
 
 ```bash
 uv run huly --json projects list
-uv run huly --json issues list --project ROA --limit 5
+uv run huly --json issues list --project DEMO --limit 5
 uv run huly --json auth status
 ```
 

--- a/scripts/live_smoke.py
+++ b/scripts/live_smoke.py
@@ -264,10 +264,10 @@ def cleanup_writes(artifacts: CreatedArtifacts) -> None:
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--project", default="ROA", help="Project identifier for smoke tests.")
+    parser.add_argument("--project", default="DEMO", help="Project identifier for smoke tests.")
     parser.add_argument(
         "--teamspace",
-        default="RoA - Staff Augmentation",
+        default="Engineering",
         help="Teamspace name used for document write checks.",
     )
     parser.add_argument(

--- a/skills/huly-cli/SKILL.md
+++ b/skills/huly-cli/SKILL.md
@@ -89,7 +89,7 @@ uv run huly auth status
 Important distinction:
 
 - workspace slug and project identifier are not the same thing
-- example from this repo: workspace `efs`, project `ROA`
+- example: workspace `my-ws`, project `DEMO`
 
 ### 3. Validate the installation
 

--- a/skills/huly-cli/references/usage.md
+++ b/skills/huly-cli/references/usage.md
@@ -100,25 +100,25 @@ uv run python scripts/live_smoke.py --allow-writes
 
 ```bash
 huly projects list
-huly projects get ROA
+huly projects get DEMO
 ```
 
 ### Issues
 
 ```bash
-huly issues list --project ROA --limit 5
-huly issues get ROA-1
-huly issues describe ROA-1
-huly issues create --project ROA --title "Example" --description "Example description"
-huly issues update ROA-1 --title "Updated title" --status done
-huly issues delete ROA-1
+huly issues list --project DEMO --limit 5
+huly issues get DEMO-1
+huly issues describe DEMO-1
+huly issues create --project DEMO --title "Example" --description "Example description"
+huly issues update DEMO-1 --title "Updated title" --status done
+huly issues delete DEMO-1
 ```
 
 ### Documents
 
 ```bash
 huly documents list --limit 5
-huly documents create --space "RoA - Staff Augmentation" --title "Example Doc"
+huly documents create --space "Engineering" --title "Example Doc"
 huly documents describe DOC_ID --set "Example content"
 huly documents update DOC_ID --title "Updated title"
 huly documents delete DOC_ID
@@ -127,8 +127,8 @@ huly documents delete DOC_ID
 ### Components
 
 ```bash
-huly components list --project ROA --limit 5
-huly components create --project ROA --label "Example Component"
+huly components list --project DEMO --limit 5
+huly components create --project DEMO --label "Example Component"
 huly components update COMPONENT_ID --label "Updated Component"
 huly components delete COMPONENT_ID
 ```
@@ -136,8 +136,8 @@ huly components delete COMPONENT_ID
 ### Milestones
 
 ```bash
-huly milestones list --project ROA --limit 5
-huly milestones create --project ROA --label "Example Milestone" --status planned
+huly milestones list --project DEMO --limit 5
+huly milestones create --project DEMO --label "Example Milestone" --status planned
 huly milestones update MILESTONE_ID --status completed
 huly milestones delete MILESTONE_ID
 ```
@@ -145,7 +145,7 @@ huly milestones delete MILESTONE_ID
 ### Templates
 
 ```bash
-huly templates list --project ROA --limit 5
+huly templates list --project DEMO --limit 5
 huly templates get TEMPLATE_ID
 huly templates describe TEMPLATE_ID
 huly templates describe TEMPLATE_ID --set "Updated description"
@@ -164,7 +164,7 @@ Prefer JSON for agent workflows:
 
 ```bash
 huly --json projects list
-huly --json issues get ROA-1
+huly --json issues get DEMO-1
 ```
 
 ## Troubleshooting

--- a/src/huly_cli/commands/auth_cmd.py
+++ b/src/huly_cli/commands/auth_cmd.py
@@ -59,7 +59,7 @@ def auth_login(
     # Resolve workspace
     if not config.workspace:
         if sys.stdin.isatty():
-            config.workspace = typer.prompt("Workspace slug", default="efs")
+            config.workspace = typer.prompt("Workspace slug")
         else:
             raise AuthError("Workspace required. Set HULY_WORKSPACE env var.")
 

--- a/src/huly_cli/commands/components.py
+++ b/src/huly_cli/commands/components.py
@@ -96,7 +96,7 @@ def components_list(
     ctx: typer.Context,
     project: Annotated[
         str | None,
-        typer.Option("--project", "-p", help="Filter by project identifier (e.g. ROA)."),
+        typer.Option("--project", "-p", help="Filter by project identifier (e.g. DEMO)."),
     ] = None,
     limit: Annotated[
         int,
@@ -186,7 +186,7 @@ def components_create(
     ctx: typer.Context,
     label: Annotated[str, typer.Option("--label", help="Component label.")] = ...,
     project: Annotated[
-        str, typer.Option("--project", help='Project identifier (e.g. "ROA").')
+        str, typer.Option("--project", help='Project identifier (e.g. "DEMO").')
     ] = ...,
     lead: Annotated[
         str | None, typer.Option("--lead", help="Lead person name (fuzzy match).")

--- a/src/huly_cli/commands/issues.py
+++ b/src/huly_cli/commands/issues.py
@@ -219,7 +219,7 @@ def issues_list(
     ctx: typer.Context,
     project: Annotated[
         str | None,
-        typer.Option("--project", "-p", help="Filter by project identifier (e.g. ROA)."),
+        typer.Option("--project", "-p", help="Filter by project identifier (e.g. DEMO)."),
     ] = None,
     status: Annotated[
         str | None,
@@ -328,7 +328,7 @@ def issues_list(
 @app.command("get")
 def issues_get(
     ctx: typer.Context,
-    identifier: str = typer.Argument(..., help="Issue identifier (e.g. ROA-1)."),
+    identifier: str = typer.Argument(..., help="Issue identifier (e.g. DEMO-1)."),
 ) -> None:
     """Get details of an issue."""
     overrides: dict = ctx.obj or {}
@@ -367,7 +367,7 @@ def issues_create(
     ctx: typer.Context,
     title: Annotated[str, typer.Option("--title", help="Issue title.")] = ...,
     project: Annotated[
-        str, typer.Option("--project", help='Project identifier (e.g. "ROA").')
+        str, typer.Option("--project", help='Project identifier (e.g. "DEMO").')
     ] = ...,
     status: Annotated[str | None, typer.Option("--status", help="Status name or id.")] = None,
     priority: Annotated[str, typer.Option("--priority", help="Priority name or number.")] = "none",
@@ -474,7 +474,7 @@ async def _create_impl(
 @app.command("update")
 def issues_update(
     ctx: typer.Context,
-    identifier: str = typer.Argument(..., help="Issue identifier (e.g. ROA-1)."),
+    identifier: str = typer.Argument(..., help="Issue identifier (e.g. DEMO-1)."),
     title: Annotated[str | None, typer.Option("--title", help="New issue title.")] = None,
     status: Annotated[str | None, typer.Option("--status", help="New status name.")] = None,
     priority: Annotated[
@@ -553,7 +553,7 @@ async def _update_impl(
 @app.command("describe")
 def issues_describe(
     ctx: typer.Context,
-    identifier: str = typer.Argument(..., help="Issue identifier (e.g. ROA-1)."),
+    identifier: str = typer.Argument(..., help="Issue identifier (e.g. DEMO-1)."),
     raw: Annotated[
         bool,
         typer.Option("--raw", help="Show raw ProseMirror JSON instead of rendered markdown."),
@@ -704,7 +704,7 @@ def issues_describe(
 @app.command("delete")
 def issues_delete(
     ctx: typer.Context,
-    identifier: str = typer.Argument(..., help="Issue identifier (e.g. ROA-1)."),
+    identifier: str = typer.Argument(..., help="Issue identifier (e.g. DEMO-1)."),
 ) -> None:
     """Delete an existing issue."""
     overrides: dict = ctx.obj or {}

--- a/src/huly_cli/commands/milestones.py
+++ b/src/huly_cli/commands/milestones.py
@@ -90,7 +90,7 @@ def milestones_list(
     ctx: typer.Context,
     project: Annotated[
         str | None,
-        typer.Option("--project", "-p", help="Filter by project identifier (e.g. ROA)."),
+        typer.Option("--project", "-p", help="Filter by project identifier (e.g. DEMO)."),
     ] = None,
     status: Annotated[
         str | None,
@@ -187,7 +187,7 @@ def milestones_create(
     ctx: typer.Context,
     label: Annotated[str, typer.Option("--label", help="Milestone label.")] = ...,
     project: Annotated[
-        str, typer.Option("--project", help='Project identifier (e.g. "ROA").')
+        str, typer.Option("--project", help='Project identifier (e.g. "DEMO").')
     ] = ...,
     status: Annotated[
         str, typer.Option("--status", help="Status: planned, in-progress, completed.")

--- a/src/huly_cli/commands/projects.py
+++ b/src/huly_cli/commands/projects.py
@@ -67,7 +67,7 @@ def projects_list(ctx: typer.Context) -> None:
 @app.command("get")
 def projects_get(
     ctx: typer.Context,
-    identifier: str = typer.Argument(..., help="Project identifier (e.g. ROA) or internal ID."),
+    identifier: str = typer.Argument(..., help="Project identifier (e.g. DEMO) or internal ID."),
 ) -> None:
     """Get details of a project."""
     overrides: dict = ctx.obj or {}

--- a/src/huly_cli/commands/templates.py
+++ b/src/huly_cli/commands/templates.py
@@ -66,7 +66,7 @@ def templates_list(
     ctx: typer.Context,
     project: Annotated[
         str | None,
-        typer.Option("--project", "-p", help="Filter by project identifier (e.g. ROA)."),
+        typer.Option("--project", "-p", help="Filter by project identifier (e.g. DEMO)."),
     ] = None,
     limit: Annotated[
         int,

--- a/src/huly_cli/config.py
+++ b/src/huly_cli/config.py
@@ -29,7 +29,7 @@ class HulyConfig:
 class AuthCache:
     account_token: str
     workspace_token: str
-    workspace_id: str  # e.g. "w-athena-efs-69cb28b3-..."
+    workspace_id: str  # e.g. "w-example-abc12345-..."
     workspace_uuid: str  # e.g. "46573ece-3150-4b3a-..."
     email: str
     workspace_slug: str
@@ -56,7 +56,7 @@ def load_config(
     toml = _load_toml_config()
 
     url = (
-        url_override or os.environ.get("HULY_URL") or toml.get("url") or "https://huly.ingenuity.ph"
+        url_override or os.environ.get("HULY_URL") or toml.get("url") or "https://huly.example.com"
     )
     workspace = (
         workspace_override or os.environ.get("HULY_WORKSPACE") or toml.get("workspace") or ""

--- a/src/huly_cli/models.py
+++ b/src/huly_cli/models.py
@@ -43,7 +43,7 @@ class Issue(BaseModel):
     id: str = Field(alias="_id")
     title: str
     description: str = ""  # blob ref (not inline text)
-    identifier: str = ""  # "ROA-1"
+    identifier: str = ""  # "DEMO-1"
     number: int = 0
     status: str = ""
     priority: int = 0

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -28,11 +28,11 @@ async def test_find_all(fake_config, fake_auth):
 async def test_find_all_with_query(fake_config, fake_auth):
     with respx.mock:
         respx.post("https://test.example.com/_transactor/api/v1/find-all/w-test-123").respond(
-            json={"value": [{"_id": "i2", "identifier": "ROA-1"}], "total": -1}
+            json={"value": [{"_id": "i2", "identifier": "DEMO-1"}], "total": -1}
         )
         async with HulyClient(fake_config, fake_auth) as client:
-            result = await client.find_all("tracker:class:Issue", query={"identifier": "ROA-1"})
-    assert result[0]["identifier"] == "ROA-1"
+            result = await client.find_all("tracker:class:Issue", query={"identifier": "DEMO-1"})
+    assert result[0]["identifier"] == "DEMO-1"
 
 
 async def test_find_all_empty_result(fake_config, fake_auth):

--- a/tests/test_issue_write_path.py
+++ b/tests/test_issue_write_path.py
@@ -19,7 +19,7 @@ def _raw_issue(**overrides: object) -> dict[str, object]:
     issue: dict[str, object] = {
         "_id": "issue-1",
         "title": "Existing issue",
-        "identifier": "ROA-1",
+        "identifier": "DEMO-1",
         "number": 1,
         "status": "tracker:status:Backlog",
         "priority": 2,
@@ -56,8 +56,8 @@ async def test_find_issue_by_identifier_or_id_falls_back_to_internal_id():
 async def test_create_impl_increments_project_sequence_and_uses_blob_ref(fake_config, fake_auth):
     project_doc = {
         "_id": "project-1",
-        "name": "Roadmap",
-        "identifier": "ROA",
+        "name": "My Project",
+        "identifier": "DEMO",
         "sequence": 16,
         "members": [],
         "owners": [],
@@ -84,7 +84,7 @@ async def test_create_impl_increments_project_sequence_and_uses_blob_ref(fake_co
         message = await issues_cmd._create_impl(
             fake_config,
             title="Fix auth drift",
-            project="ROA",
+            project="DEMO",
             status=None,
             priority="high",
             assignee=None,
@@ -103,7 +103,7 @@ async def test_create_impl_increments_project_sequence_and_uses_blob_ref(fake_co
     assert create_tx["objectClass"] == "tracker:class:Issue"
     assert create_tx["objectSpace"] == "project-1"
     assert create_tx["attributes"]["number"] == 17
-    assert create_tx["attributes"]["identifier"] == "ROA-17"
+    assert create_tx["attributes"]["identifier"] == "DEMO-17"
     assert create_tx["attributes"]["rank"] == "0|i0002g:"
     assert create_tx["attributes"]["description"] is None
     assert create_tx["attributes"]["status"] == "tracker:status:Backlog"
@@ -111,7 +111,7 @@ async def test_create_impl_increments_project_sequence_and_uses_blob_ref(fake_co
     assert description_tx["objectClass"] == "tracker:class:Issue"
     assert description_tx["objectId"] == create_tx["objectId"]
     assert description_tx["operations"] == {"description": "blob-description-1"}
-    assert "ROA-17" in message
+    assert "DEMO-17" in message
     create_description_mock.assert_awaited_once()
 
 
@@ -133,7 +133,7 @@ async def test_update_impl_resolves_custom_status_and_unassigns(fake_config, fak
     ):
         await issues_cmd._update_impl(
             fake_config,
-            identifier="ROA-1",
+            identifier="DEMO-1",
             title="Updated title",
             status="UAT",
             priority="high",
@@ -165,10 +165,10 @@ def test_issues_describe_set_creates_blob_ref_when_missing(fake_auth):
         patch("huly_cli.client.HulyClient.create_description", create_description_mock),
         patch("huly_cli.client.HulyClient.tx", tx_mock),
     ):
-        result = runner.invoke(app, ["issues", "describe", "ROA-1", "--set", "hello world"])
+        result = runner.invoke(app, ["issues", "describe", "DEMO-1", "--set", "hello world"])
 
     assert result.exit_code == 0, result.output
-    assert "Description updated for ROA-1." in result.output
+    assert "Description updated for DEMO-1." in result.output
     assert tx_mock.await_args.args[0]["operations"] == {"description": "blob-description-2"}
 
 
@@ -185,10 +185,10 @@ def test_issues_describe_set_falls_back_to_inline_markup_when_blob_create_fails(
         patch("huly_cli.client.HulyClient.create_description", create_description_mock),
         patch("huly_cli.client.HulyClient.tx", tx_mock),
     ):
-        result = runner.invoke(app, ["issues", "describe", "ROA-1", "--set", "hello world"])
+        result = runner.invoke(app, ["issues", "describe", "DEMO-1", "--set", "hello world"])
 
     assert result.exit_code == 0, result.output
-    assert "Description updated for ROA-1." in result.output
+    assert "Description updated for DEMO-1." in result.output
     description_value = tx_mock.await_args.args[0]["operations"]["description"]
     assert isinstance(description_value, str)
     assert description_value.startswith("{")
@@ -284,7 +284,7 @@ def test_issues_describe_reads_inline_markup_without_collaborator(fake_auth):
             new=AsyncMock(return_value=[_raw_issue(description=inline_markup)]),
         ),
     ):
-        result = runner.invoke(app, ["--json", "issues", "describe", "ROA-1"])
+        result = runner.invoke(app, ["--json", "issues", "describe", "DEMO-1"])
 
     assert result.exit_code == 0, result.output
     data = json.loads(result.output)
@@ -340,10 +340,10 @@ def test_issues_delete_removes_issue(fake_auth):
         ),
         patch("huly_cli.client.HulyClient.tx", tx_mock),
     ):
-        result = runner.invoke(app, ["issues", "delete", "ROA-1"])
+        result = runner.invoke(app, ["issues", "delete", "DEMO-1"])
 
     assert result.exit_code == 0, result.output
-    assert "Issue ROA-1 deleted." in result.output
+    assert "Issue DEMO-1 deleted." in result.output
     assert tx_mock.await_args.args[0] == {
         "_class": "core:class:TxRemoveDoc",
         "objectClass": "tracker:class:Issue",
@@ -415,7 +415,7 @@ def test_issues_get_formats_workspace_specific_status(fake_auth):
         ),
         patch("huly_cli.commands.issues.print_item", side_effect=capture),
     ):
-        result = runner.invoke(app, ["issues", "get", "ROA-1"])
+        result = runner.invoke(app, ["issues", "get", "DEMO-1"])
 
     assert result.exit_code == 0, result.output
     assert captured["data"]["status"] == "uat"
@@ -426,8 +426,8 @@ def test_issues_list_fans_out_multi_status_queries(fake_auth):
     captured: dict[str, object] = {}
     find_all_mock = AsyncMock(
         side_effect=[
-            [_raw_issue(_id="issue-1", identifier="ROA-1", status="status-1")],
-            [_raw_issue(_id="issue-2", identifier="ROA-2", status="status-2")],
+            [_raw_issue(_id="issue-1", identifier="DEMO-1", status="status-1")],
+            [_raw_issue(_id="issue-2", identifier="DEMO-2", status="status-2")],
             [],
         ]
     )
@@ -459,5 +459,5 @@ def test_issues_list_fans_out_multi_status_queries(fake_auth):
     assert result.exit_code == 0, result.output
     assert find_all_mock.await_args_list[0].kwargs["query"] == {"status": "status-1"}
     assert find_all_mock.await_args_list[1].kwargs["query"] == {"status": "status-2"}
-    assert [item["identifier"] for item in captured["items"]] == ["ROA-1", "ROA-2"]
+    assert [item["identifier"] for item in captured["items"]] == ["DEMO-1", "DEMO-2"]
     assert [item["status"] for item in captured["items"]] == ["ready", "ready"]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -21,7 +21,7 @@ class TestIssue:
         raw = {
             "_id": "abc123",
             "title": "Test",
-            "identifier": "ROA-1",
+            "identifier": "DEMO-1",
             "number": 1,
             "status": "tracker:status:Backlog",
             "priority": 2,
@@ -104,8 +104,8 @@ class TestIssue:
 
 class TestPerson:
     def test_person_display_name(self):
-        p = Person.model_validate({"_id": "p1", "name": "Naranjo,Kyle"})
-        assert p.display_name == "Kyle Naranjo"
+        p = Person.model_validate({"_id": "p1", "name": "Doe,Jane"})
+        assert p.display_name == "Jane Doe"
 
     def test_person_single_name(self):
         p = Person.model_validate({"_id": "p2", "name": "Admin"})

--- a/tests/test_read_path_compat.py
+++ b/tests/test_read_path_compat.py
@@ -38,12 +38,12 @@ async def test_find_all_normalizes_scalar_query_values_and_lookup_map(fake_confi
         async with HulyClient(fake_config, fake_auth) as client:
             result = await client.find_all(
                 "tracker:class:Issue",
-                query={"_id": "issue-1", "identifier": "ROA-1"},
+                query={"_id": "issue-1", "identifier": "DEMO-1"},
             )
 
     assert result[0]["_class"] == "tracker:class:Issue"
     assert result[0]["_id"] == "issue-1"
-    assert result[0]["identifier"] == "ROA-1"
+    assert result[0]["identifier"] == "DEMO-1"
     assert result[0]["$lookup"]["assignee"] == {"_id": "person-1", "name": "Doe,John"}
     assert result[0]["$lookup"]["reviewers"] == [
         {"_id": "person-1", "name": "Doe,John"},


### PR DESCRIPTION
## Summary
- Replace workspace-specific URLs (`huly.ingenuity.ph`), slugs (`efs`), project identifiers (`ROA`), and personal names with generic placeholders across docs, help strings, tests, and config defaults
- Add a `release` job to the publish workflow so future tag pushes automatically create a matching GitHub Release (fixes release/deployment mismatch)
- Remove hardcoded workspace default from auth prompt

## Test plan
- [x] All 159 tests pass locally
- [ ] CI passes (lint + tests + build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)