### PR TITLE
fix: allow null defaultIssueStatus in Project model

### DIFF
--- a/src/huly_cli/models.py
+++ b/src/huly_cli/models.py
@@ -79,7 +79,7 @@ class Project(BaseModel):
     sequence: int = 0
     members: list[str] = []
     owners: list[str] = []
-    default_issue_status: str = Field("", alias="defaultIssueStatus")
+    default_issue_status: str | None = Field(None, alias="defaultIssueStatus")
     private: bool = False
     archived: bool = False
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -150,6 +150,22 @@ class TestProject:
         proj = Project.model_validate(raw)
         assert proj.default_issue_status == "tracker:status:Backlog"
 
+    def test_project_null_default_issue_status(self):
+        """Regression: API may return defaultIssueStatus=null; model must accept it.
+
+        Previously `default_issue_status: str` raised a ValidationError when the
+        API returned `null`, crashing `huly projects list`. See issue #11.
+        """
+        raw = {
+            "_id": "p1",
+            "identifier": "CORE",
+            "name": "Test",
+            "defaultIssueStatus": None,
+            "archived": False,
+        }
+        proj = Project.model_validate(raw)
+        assert proj.default_issue_status is None
+
 
 # ── PersonAccount ──────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Fixes `huly projects list` crashing with a Pydantic `ValidationError` when any project in the workspace has `defaultIssueStatus: null` in the API response.

## Root Cause

`Project.default_issue_status` was typed as `str`, which Pydantic rejects when the API returns `null`. The `""` default only applies when the field is absent, not when it is explicitly `null`.

## Fix

Changed the field to `Optional[str]` (or `str | None`) so Pydantic accepts both `null` and missing values.

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)