### PR TITLE
docs: make pipx the primary install recommendation

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,33 @@ If you run `huly issues list --project MY-WS`, it will fail because `MY-WS` is n
 
 ### Option 1: Install from PyPI
 
-Use this if you only want the CLI and are not modifying the source:
+Use this if you only want the CLI and are not modifying the source.
+
+The package name is `huly-cli`. The executable is `huly`.
+
+#### Recommended: `pipx` (standalone CLI install)
+
+[`pipx`](https://pipx.pypa.io/) is the recommended installer for standalone
+Python CLI tools. It creates an isolated environment per tool, puts the
+executable on `PATH` automatically, and works out of the box on PEP 668
+environments (including modern macOS with Homebrew-managed Python, where bare
+`pip install` is blocked with `externally-managed-environment`).
+
+```bash
+pipx install huly-cli
+huly --help
+```
+
+Upgrade an existing install:
+
+```bash
+pipx upgrade huly-cli
+```
+
+#### Alternative: `pip` (virtualenv or CI)
+
+Use `pip` if you are installing into an existing virtualenv or a controlled
+CI environment:
 
 ```bash
 pip install huly-cli
@@ -68,24 +94,10 @@ Upgrade an existing install:
 pip install --upgrade huly-cli
 ```
 
-The package name is `huly-cli`. The executable is `huly`.
-
-If `huly` is not found after installing, the install directory may not be on your
-`PATH`. Common fixes:
-
-```bash
-# Check where pip installed it
-python -m site --user-base
-# Typical paths to add:
-#   macOS/Linux: ~/.local/bin
-#   Windows:     %APPDATA%\Python\PythonXY\Scripts
-
-# macOS / Linux — add to your shell profile (~/.zshrc, ~/.bashrc, etc.):
-export PATH="$HOME/.local/bin:$PATH"
-
-# Or install with pipx, which handles PATH automatically:
-pipx install huly-cli
-```
+If `huly` is not found after a user-site `pip install`, the install
+directory may not be on your `PATH` (e.g. `~/.local/bin` on macOS/Linux or
+`%APPDATA%\Python\PythonXY\Scripts` on Windows). Either add that directory
+to `PATH`, or switch to `pipx`, which handles `PATH` automatically.
 
 ### Option 2: Use from a source checkout
 
@@ -319,7 +331,13 @@ Expected result at the time of verification:
 
 The package is published on PyPI as `huly-cli`.
 
-Install it with:
+Install it with `pipx` (recommended for end-users):
+
+```bash
+pipx install huly-cli
+```
+
+Or with `pip` (for virtualenvs or CI):
 
 ```bash
 pip install huly-cli

--- a/tests/test_readme_install.py
+++ b/tests/test_readme_install.py
@@ -1,0 +1,93 @@
+"""Validate that README.md recommends pipx as the primary install method.
+
+Background: On PEP 668-compliant environments (e.g. modern macOS with
+Homebrew-managed Python), bare `pip install` is blocked with
+"externally-managed-environment". The Python Packaging Authority recommends
+`pipx` for installing standalone CLI tools. The README must therefore lead
+with `pipx install huly-cli` rather than `pip install huly-cli`.
+"""
+
+from pathlib import Path
+
+README = Path(__file__).resolve().parent.parent / "README.md"
+
+
+def _read_readme() -> str:
+    return README.read_text(encoding="utf-8")
+
+
+def _slice_install_section(text: str) -> str:
+    """Return the text of the PyPI install subsection.
+
+    The section starts at `### Option 1` (Install from PyPI) and ends at the
+    next top-level or sibling heading (`### Option 2` or `## `).
+    """
+    start_marker = "### Option 1"
+    start = text.find(start_marker)
+    assert start != -1, "README is missing '### Option 1' install heading"
+
+    # Find the next sibling/ancestor heading after the start.
+    rest = text[start + len(start_marker) :]
+    end_candidates = [rest.find("\n### "), rest.find("\n## ")]
+    end_offsets = [c for c in end_candidates if c != -1]
+    assert end_offsets, "Could not find end of Option 1 section"
+    end = start + len(start_marker) + min(end_offsets)
+    return text[start:end]
+
+
+def test_pipx_appears_before_pip_in_install_section() -> None:
+    """pipx install huly-cli must be documented before pip install huly-cli."""
+    section = _slice_install_section(_read_readme())
+
+    pipx_idx = section.find("pipx install huly-cli")
+    pip_idx = section.find("pip install huly-cli")
+
+    assert pipx_idx != -1, (
+        "Option 1 section does not mention `pipx install huly-cli`. "
+        "pipx is the recommended install method for standalone CLI tools."
+    )
+    assert pip_idx != -1, (
+        "Option 1 section does not mention `pip install huly-cli`. "
+        "pip should still be documented as a secondary option."
+    )
+    assert pipx_idx < pip_idx, (
+        "`pipx install huly-cli` must appear BEFORE `pip install huly-cli` "
+        "in the Option 1 install section. pipx is the primary recommendation "
+        "for end-users; pip is secondary (virtualenv/CI)."
+    )
+
+
+def test_pipx_upgrade_command_documented() -> None:
+    """The README should document `pipx upgrade huly-cli` for pipx users."""
+    text = _read_readme()
+    assert "pipx upgrade huly-cli" in text, (
+        "README is missing `pipx upgrade huly-cli`. pipx users need a "
+        "documented upgrade command alongside the pipx install instruction."
+    )
+
+
+def test_packaging_section_leads_with_pipx() -> None:
+    """The 'Packaging And PyPI' section at the bottom should also lead with pipx."""
+    text = _read_readme()
+    marker = "## Packaging And PyPI"
+    start = text.find(marker)
+    assert start != -1, "README is missing the 'Packaging And PyPI' section"
+
+    # Section ends at the next `## ` heading.
+    rest = text[start + len(marker) :]
+    end_offset = rest.find("\n## ")
+    end = start + len(marker) + (end_offset if end_offset != -1 else len(rest))
+    section = text[start:end]
+
+    pipx_idx = section.find("pipx install huly-cli")
+    pip_idx = section.find("pip install huly-cli")
+
+    assert pipx_idx != -1, (
+        "'Packaging And PyPI' section does not mention "
+        "`pipx install huly-cli`. It should be consistent with Option 1."
+    )
+    if pip_idx != -1:
+        assert pipx_idx < pip_idx, (
+            "In 'Packaging And PyPI', `pipx install huly-cli` must appear "
+            "before `pip install huly-cli`."
+        )


### PR DESCRIPTION
## Summary

- Promotes `pipx install huly-cli` to the primary install recommendation for end-users
- Keeps `pip install huly-cli` as the documented secondary path (virtualenv / CI)
- Adds `pipx upgrade huly-cli` as the upgrade command for pipx users
- Updates the Packaging section at the bottom for consistency

## Why

On modern macOS with Homebrew-managed Python (and any PEP 668-compliant environment), bare `pip install` is blocked with `externally-managed-environment`. `pipx` is purpose-built for standalone CLI tools: it creates an isolated venv automatically and puts the binary on `PATH` without manual configuration.

The Python Packaging Authority recommends `pipx` for installing CLI applications.

Closes #12

Generated with [Claude Code](https://claude.com/claude-code)