### PR TITLE
test: add coverage for auth, projects get, milestones, components, templates, and issues create

### DIFF
--- a/tests/test_auth_cmd.py
+++ b/tests/test_auth_cmd.py
@@ -1,0 +1,279 @@
+"""Regression tests for `huly auth login` and `huly auth status`."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from typer.testing import CliRunner
+
+from huly_cli.config import AuthCache, HulyConfig
+from huly_cli.errors import AuthError
+from huly_cli.main import app
+
+runner = CliRunner()
+
+
+FAKE_AUTH = AuthCache(
+    account_token="acct-tok",
+    workspace_token="ws-tok",
+    workspace_id="w-fake",
+    workspace_uuid="uuid-fake",
+    email="user@example.com",
+    workspace_slug="fake-ws",
+    account_id="acc-fake",
+    cached_at=1700000000.0,
+)
+
+
+# ── auth login ────────────────────────────────────────────────────────────────
+
+
+def test_auth_login_uses_cli_credentials_and_saves_config():
+    """auth login with --email/--password/--workspace stores tokens and persists config."""
+    fake_config = HulyConfig(
+        url="https://huly.example.com",
+        workspace="fake-ws",
+        email=None,
+        password=None,
+    )
+    load_config_mock = MagicMock(return_value=fake_config)
+    save_config_mock = MagicMock()
+    login_mock = AsyncMock(return_value=FAKE_AUTH)
+
+    with (
+        patch("huly_cli.commands.auth_cmd.load_config", load_config_mock),
+        patch("huly_cli.commands.auth_cmd.save_config", save_config_mock),
+        patch("huly_cli.commands.auth_cmd.login", login_mock),
+    ):
+        result = runner.invoke(
+            app,
+            ["auth", "login", "--email", "user@example.com", "--password", "secret"],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "Logged in as" in result.output
+    assert "user@example.com" in result.output
+    assert "fake-ws" in result.output
+    login_mock.assert_awaited_once()
+    save_config_mock.assert_called_once()
+    saved_config = save_config_mock.call_args.args[0]
+    assert saved_config.email == "user@example.com"
+    assert saved_config.password == "secret"
+
+
+def test_auth_login_uses_config_credentials_when_flags_omitted():
+    """auth login should fall back to config-resident credentials when no flags are passed."""
+    fake_config = HulyConfig(
+        url="https://huly.example.com",
+        workspace="fake-ws",
+        email="env-user@example.com",
+        password="env-pass",
+    )
+    login_mock = AsyncMock(return_value=FAKE_AUTH)
+
+    with (
+        patch("huly_cli.commands.auth_cmd.load_config", MagicMock(return_value=fake_config)),
+        patch("huly_cli.commands.auth_cmd.save_config", MagicMock()),
+        patch("huly_cli.commands.auth_cmd.login", login_mock),
+    ):
+        result = runner.invoke(app, ["auth", "login"])
+
+    assert result.exit_code == 0, result.output
+    login_mock.assert_awaited_once()
+
+
+def test_auth_login_errors_when_email_missing_in_non_tty():
+    """auth login without email and without TTY should exit with code 2."""
+    fake_config = HulyConfig(
+        url="https://huly.example.com",
+        workspace="fake-ws",
+        email=None,
+        password=None,
+    )
+    login_mock = AsyncMock(return_value=FAKE_AUTH)
+
+    with (
+        patch("huly_cli.commands.auth_cmd.load_config", MagicMock(return_value=fake_config)),
+        patch("huly_cli.commands.auth_cmd.save_config", MagicMock()),
+        patch("huly_cli.commands.auth_cmd.login", login_mock),
+    ):
+        result = runner.invoke(app, ["auth", "login"])
+
+    # CliRunner stdin is not a tty, so missing email should raise AuthError
+    assert result.exit_code != 0
+    login_mock.assert_not_awaited()
+
+
+def test_auth_login_errors_when_password_missing_in_non_tty():
+    """auth login with email but no password (non-tty) should exit non-zero."""
+    fake_config = HulyConfig(
+        url="https://huly.example.com",
+        workspace="fake-ws",
+        email="u@example.com",
+        password=None,
+    )
+    login_mock = AsyncMock(return_value=FAKE_AUTH)
+
+    with (
+        patch("huly_cli.commands.auth_cmd.load_config", MagicMock(return_value=fake_config)),
+        patch("huly_cli.commands.auth_cmd.save_config", MagicMock()),
+        patch("huly_cli.commands.auth_cmd.login", login_mock),
+    ):
+        result = runner.invoke(app, ["auth", "login"])
+
+    assert result.exit_code != 0
+    login_mock.assert_not_awaited()
+
+
+def test_auth_login_errors_when_workspace_missing_in_non_tty():
+    """auth login with email/password but no workspace (non-tty) should exit non-zero."""
+    fake_config = HulyConfig(
+        url="https://huly.example.com",
+        workspace="",
+        email=None,
+        password=None,
+    )
+    login_mock = AsyncMock(return_value=FAKE_AUTH)
+
+    with (
+        patch("huly_cli.commands.auth_cmd.load_config", MagicMock(return_value=fake_config)),
+        patch("huly_cli.commands.auth_cmd.save_config", MagicMock()),
+        patch("huly_cli.commands.auth_cmd.login", login_mock),
+    ):
+        result = runner.invoke(
+            app,
+            ["auth", "login", "--email", "u@example.com", "--password", "pw"],
+        )
+
+    assert result.exit_code != 0
+    login_mock.assert_not_awaited()
+
+
+def test_auth_login_propagates_auth_error_with_exit_code_2():
+    """AuthError raised from login() surfaces as exit code 2."""
+    fake_config = HulyConfig(
+        url="https://huly.example.com",
+        workspace="fake-ws",
+        email="u@example.com",
+        password="pw",
+    )
+    login_mock = AsyncMock(side_effect=AuthError("Bad credentials"))
+
+    with (
+        patch("huly_cli.commands.auth_cmd.load_config", MagicMock(return_value=fake_config)),
+        patch("huly_cli.commands.auth_cmd.save_config", MagicMock()),
+        patch("huly_cli.commands.auth_cmd.login", login_mock),
+    ):
+        result = runner.invoke(app, ["auth", "login"])
+
+    assert result.exit_code == 2
+    login_mock.assert_awaited_once()
+
+
+def test_auth_login_propagates_generic_error_with_exit_code_1():
+    """A non-AuthError exception during login surfaces as exit code 1."""
+    fake_config = HulyConfig(
+        url="https://huly.example.com",
+        workspace="fake-ws",
+        email="u@example.com",
+        password="pw",
+    )
+    login_mock = AsyncMock(side_effect=RuntimeError("network down"))
+
+    with (
+        patch("huly_cli.commands.auth_cmd.load_config", MagicMock(return_value=fake_config)),
+        patch("huly_cli.commands.auth_cmd.save_config", MagicMock()),
+        patch("huly_cli.commands.auth_cmd.login", login_mock),
+    ):
+        result = runner.invoke(app, ["auth", "login"])
+
+    assert result.exit_code == 1
+    login_mock.assert_awaited_once()
+
+
+# ── auth status ───────────────────────────────────────────────────────────────
+
+
+def test_auth_status_authenticated():
+    """auth status reports authenticated when check_auth_status returns a positive payload."""
+    fake_config = HulyConfig(
+        url="https://huly.example.com",
+        workspace="fake-ws",
+    )
+    status_payload = {
+        "authenticated": True,
+        "email": "user@example.com",
+        "workspace": "fake-ws",
+        "workspace_id": "w-fake",
+        "workspace_uuid": "uuid-fake",
+        "token_age_seconds": 42,
+        "token_age_human": "42s",
+    }
+    check_mock = AsyncMock(return_value=status_payload)
+
+    with (
+        patch("huly_cli.commands.auth_cmd.load_config", MagicMock(return_value=fake_config)),
+        patch("huly_cli.commands.auth_cmd.check_auth_status", check_mock),
+    ):
+        result = runner.invoke(app, ["auth", "status"])
+
+    assert result.exit_code == 0, result.output
+    assert "user@example.com" in result.output
+    check_mock.assert_awaited_once()
+
+
+def test_auth_status_unauthenticated_stale_cache():
+    """auth status surfaces an unauthenticated payload (stale/missing cache)."""
+    fake_config = HulyConfig(
+        url="https://huly.example.com",
+        workspace="fake-ws",
+    )
+    status_payload = {
+        "authenticated": False,
+        "email": None,
+        "workspace": None,
+        "token_age": None,
+    }
+    check_mock = AsyncMock(return_value=status_payload)
+
+    with (
+        patch("huly_cli.commands.auth_cmd.load_config", MagicMock(return_value=fake_config)),
+        patch("huly_cli.commands.auth_cmd.check_auth_status", check_mock),
+    ):
+        result = runner.invoke(app, ["auth", "status"])
+
+    assert result.exit_code == 0, result.output
+    assert "False" in result.output or "false" in result.output
+    check_mock.assert_awaited_once()
+
+
+def test_auth_status_json_mode():
+    """auth status emits JSON envelope when --json is set."""
+    import json as json_mod
+
+    fake_config = HulyConfig(
+        url="https://huly.example.com",
+        workspace="fake-ws",
+    )
+    status_payload = {
+        "authenticated": True,
+        "email": "user@example.com",
+        "workspace": "fake-ws",
+        "workspace_id": "w-fake",
+        "workspace_uuid": "uuid-fake",
+        "token_age_seconds": 1,
+        "token_age_human": "1s",
+    }
+    check_mock = AsyncMock(return_value=status_payload)
+
+    with (
+        patch("huly_cli.commands.auth_cmd.load_config", MagicMock(return_value=fake_config)),
+        patch("huly_cli.commands.auth_cmd.check_auth_status", check_mock),
+    ):
+        result = runner.invoke(app, ["--json", "auth", "status"])
+
+    assert result.exit_code == 0, result.output
+    data = json_mod.loads(result.output)
+    assert data["ok"] is True
+    assert data["data"]["authenticated"] is True
+    assert data["data"]["email"] == "user@example.com"

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -430,3 +430,290 @@ def test_components_delete_removes_component():
         "objectSpace": "proj1",
         "objectId": "c1",
     }
+
+
+# ── projects get ───────────────────────────────────────────────────────────────
+
+
+def test_projects_get_by_identifier():
+    """projects get DEMO returns project details when identifier matches (case-insensitive)."""
+    project_data = [
+        {
+            "_id": "p-demo",
+            "name": "Demo Project",
+            "identifier": "DEMO",
+            "members": ["a1", "a2"],
+            "owners": ["a1"],
+            "sequence": 17,
+            "description": "A demo project.",
+            "defaultIssueStatus": "tracker:status:Backlog",
+            "private": False,
+            "archived": False,
+        }
+    ]
+    find_mock = AsyncMock(return_value=project_data)
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["projects", "get", "demo"])
+    assert result.exit_code == 0, result.output
+    assert "DEMO" in result.output
+    assert "Demo Project" in result.output
+
+
+def test_projects_get_by_internal_id():
+    """projects get matches by internal _id when identifier doesn't match."""
+    project_data = [
+        {
+            "_id": "p-demo",
+            "name": "Demo Project",
+            "identifier": "DEMO",
+            "members": [],
+            "owners": [],
+            "sequence": 0,
+            "description": "",
+            "defaultIssueStatus": "",
+            "private": False,
+            "archived": False,
+        }
+    ]
+    find_mock = AsyncMock(return_value=project_data)
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["projects", "get", "p-demo"])
+    assert result.exit_code == 0, result.output
+    assert "Demo Project" in result.output
+
+
+def test_projects_get_not_found_exits_nonzero():
+    """projects get raises NotFoundError when no project matches the identifier."""
+    project_data = [
+        {
+            "_id": "p1",
+            "name": "Other Project",
+            "identifier": "OTHER",
+            "members": [],
+            "owners": [],
+            "sequence": 0,
+            "description": "",
+            "defaultIssueStatus": "",
+            "private": False,
+            "archived": False,
+        }
+    ]
+    find_mock = AsyncMock(return_value=project_data)
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["projects", "get", "MISSING"])
+    assert result.exit_code == 1
+    assert "not found" in result.output.lower() or "MISSING" in result.output
+
+
+def test_projects_get_json_mode():
+    """projects get emits JSON envelope when --json is set."""
+    import json as json_mod
+
+    project_data = [
+        {
+            "_id": "p-demo",
+            "name": "Demo Project",
+            "identifier": "DEMO",
+            "members": [],
+            "owners": [],
+            "sequence": 0,
+            "description": "",
+            "defaultIssueStatus": "",
+            "private": False,
+            "archived": False,
+        }
+    ]
+    find_mock = AsyncMock(return_value=project_data)
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["--json", "projects", "get", "DEMO"])
+    assert result.exit_code == 0, result.output
+    data = json_mod.loads(result.output)
+    assert data["ok"] is True
+    assert data["data"]["identifier"] == "DEMO"
+    assert data["data"]["name"] == "Demo Project"
+
+
+# ── components create / update ────────────────────────────────────────────────
+
+
+def test_components_create_writes_create_doc_tx():
+    """components create resolves project, generates an id, and emits a TxCreateDoc."""
+    project_data = [
+        {
+            "_id": "proj1",
+            "name": "Test Project",
+            "identifier": "TP",
+            "members": [],
+            "owners": [],
+            "sequence": 0,
+            "description": "",
+            "defaultIssueStatus": "",
+            "private": False,
+            "archived": False,
+        }
+    ]
+    tx_mock = AsyncMock(return_value={})
+    find_mock = AsyncMock(return_value=project_data)
+
+    with (
+        _auth_patch(),
+        patch("huly_cli.client.HulyClient.find_all", find_mock),
+        patch("huly_cli.client.HulyClient.tx", tx_mock),
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "components",
+                "create",
+                "--label",
+                "Auth Service",
+                "--project",
+                "TP",
+                "--description",
+                "Handles auth",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "Component created" in result.output
+    create_tx = tx_mock.await_args.args[0]
+    assert create_tx["_class"] == "core:class:TxCreateDoc"
+    assert create_tx["objectClass"] == "tracker:class:Component"
+    assert create_tx["objectSpace"] == "proj1"
+    assert create_tx["attributes"]["label"] == "Auth Service"
+    assert create_tx["attributes"]["description"] == "Handles auth"
+    assert create_tx["attributes"]["lead"] is None
+
+
+def test_components_create_with_lead_resolves_person():
+    """components create with --lead fuzzy-matches the lead person and stores the person id."""
+    project_data = [
+        {
+            "_id": "proj1",
+            "name": "Test Project",
+            "identifier": "TP",
+            "members": [],
+            "owners": [],
+            "sequence": 0,
+            "description": "",
+            "defaultIssueStatus": "",
+            "private": False,
+            "archived": False,
+        }
+    ]
+    person_data = [{"_id": "person-1", "name": "Doe,John"}]
+    find_mock = AsyncMock(side_effect=[project_data, person_data])
+    tx_mock = AsyncMock(return_value={})
+
+    with (
+        _auth_patch(),
+        patch("huly_cli.client.HulyClient.find_all", find_mock),
+        patch("huly_cli.client.HulyClient.tx", tx_mock),
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "components",
+                "create",
+                "--label",
+                "Auth Service",
+                "--project",
+                "TP",
+                "--lead",
+                "john",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    create_tx = tx_mock.await_args.args[0]
+    assert create_tx["attributes"]["lead"] == "person-1"
+
+
+def test_components_create_project_not_found_exits_nonzero():
+    """components create exits with code 1 when the project identifier does not resolve."""
+    find_mock = AsyncMock(return_value=[])  # no projects
+    tx_mock = AsyncMock(return_value={})
+
+    with (
+        _auth_patch(),
+        patch("huly_cli.client.HulyClient.find_all", find_mock),
+        patch("huly_cli.client.HulyClient.tx", tx_mock),
+    ):
+        result = runner.invoke(
+            app,
+            ["components", "create", "--label", "X", "--project", "MISSING"],
+        )
+
+    assert result.exit_code == 1
+    tx_mock.assert_not_awaited()
+
+
+def test_components_update_writes_update_doc_tx():
+    """components update applies provided fields as a TxUpdateDoc."""
+    tx_mock = AsyncMock(return_value={})
+
+    with (
+        _auth_patch(),
+        patch("huly_cli.client.HulyClient.find_all", new=AsyncMock(return_value=COMPONENT_DATA)),
+        patch("huly_cli.client.HulyClient.tx", tx_mock),
+    ):
+        result = runner.invoke(
+            app,
+            ["components", "update", "c1", "--label", "Renamed", "--description", "Updated"],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "Component c1 updated." in result.output
+    update_tx = tx_mock.await_args.args[0]
+    assert update_tx["_class"] == "core:class:TxUpdateDoc"
+    assert update_tx["objectClass"] == "tracker:class:Component"
+    assert update_tx["objectSpace"] == "proj1"
+    assert update_tx["objectId"] == "c1"
+    assert update_tx["operations"] == {"label": "Renamed", "description": "Updated"}
+
+
+def test_components_update_unassigns_lead_with_empty_string():
+    """components update --lead "" should null out the lead field."""
+    tx_mock = AsyncMock(return_value={})
+
+    with (
+        _auth_patch(),
+        patch("huly_cli.client.HulyClient.find_all", new=AsyncMock(return_value=COMPONENT_DATA)),
+        patch("huly_cli.client.HulyClient.tx", tx_mock),
+    ):
+        result = runner.invoke(app, ["components", "update", "c1", "--lead", ""])
+
+    assert result.exit_code == 0, result.output
+    update_tx = tx_mock.await_args.args[0]
+    assert update_tx["operations"] == {"lead": None}
+
+
+def test_components_update_no_fields_warns_and_skips_tx():
+    """components update with no fields prints a warning and does not emit a tx."""
+    tx_mock = AsyncMock(return_value={})
+
+    with (
+        _auth_patch(),
+        patch("huly_cli.client.HulyClient.find_all", new=AsyncMock(return_value=COMPONENT_DATA)),
+        patch("huly_cli.client.HulyClient.tx", tx_mock),
+    ):
+        result = runner.invoke(app, ["components", "update", "c1"])
+
+    assert result.exit_code == 0, result.output
+    tx_mock.assert_not_awaited()
+
+
+def test_components_update_not_found_exits_nonzero():
+    """components update exits with code 1 when the component is not found."""
+    find_mock = AsyncMock(return_value=[])
+    tx_mock = AsyncMock(return_value={})
+
+    with (
+        _auth_patch(),
+        patch("huly_cli.client.HulyClient.find_all", find_mock),
+        patch("huly_cli.client.HulyClient.tx", tx_mock),
+    ):
+        result = runner.invoke(app, ["components", "update", "missing-id", "--label", "X"])
+
+    assert result.exit_code == 1
+    tx_mock.assert_not_awaited()

--- a/tests/test_commands_new.py
+++ b/tests/test_commands_new.py
@@ -269,3 +269,466 @@ def test_milestones_delete_removes_milestone():
         "objectSpace": "p1",
         "objectId": "m1",
     }
+
+
+# ── _parse_date_ms unit tests ─────────────────────────────────────────────────
+
+
+def test_parse_date_ms_valid_date_returns_utc_milliseconds():
+    """_parse_date_ms parses YYYY-MM-DD and returns UTC ms timestamp."""
+    from huly_cli.commands.milestones import _parse_date_ms
+
+    # 2024-06-15 00:00:00 UTC == 1718409600 seconds == 1718409600000 ms
+    assert _parse_date_ms("2024-06-15") == 1718409600000
+
+
+def test_parse_date_ms_invalid_format_raises_value_error():
+    """_parse_date_ms raises ValueError for malformed date strings."""
+    import pytest
+
+    from huly_cli.commands.milestones import _parse_date_ms
+
+    with pytest.raises(ValueError):
+        _parse_date_ms("not-a-date")
+
+
+def test_parse_date_ms_empty_string_raises_value_error():
+    """_parse_date_ms rejects empty strings (caller handles None separately)."""
+    import pytest
+
+    from huly_cli.commands.milestones import _parse_date_ms
+
+    with pytest.raises(ValueError):
+        _parse_date_ms("")
+
+
+def test_parse_date_ms_wrong_format_raises_value_error():
+    """_parse_date_ms rejects formats other than YYYY-MM-DD."""
+    import pytest
+
+    from huly_cli.commands.milestones import _parse_date_ms
+
+    with pytest.raises(ValueError):
+        _parse_date_ms("06/15/2024")
+
+
+# ── milestones create ─────────────────────────────────────────────────────────
+
+
+PROJECT_DATA = [
+    {
+        "_id": "p1",
+        "name": "Test Project",
+        "identifier": "TP",
+        "members": [],
+        "owners": [],
+        "sequence": 0,
+        "description": "",
+        "defaultIssueStatus": "",
+        "private": False,
+        "archived": False,
+    }
+]
+
+
+def test_milestones_create_writes_create_doc_tx():
+    """milestones create resolves project, generates id, and emits a TxCreateDoc."""
+    find_mock = AsyncMock(return_value=PROJECT_DATA)
+    tx_mock = AsyncMock(return_value={})
+
+    with (
+        _auth_patch(),
+        patch("huly_cli.client.HulyClient.find_all", find_mock),
+        patch("huly_cli.client.HulyClient.tx", tx_mock),
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "milestones",
+                "create",
+                "--label",
+                "Sprint 1",
+                "--project",
+                "TP",
+                "--status",
+                "planned",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "Milestone created" in result.output
+    create_tx = tx_mock.await_args.args[0]
+    assert create_tx["_class"] == "core:class:TxCreateDoc"
+    assert create_tx["objectClass"] == "tracker:class:Milestone"
+    assert create_tx["objectSpace"] == "p1"
+    assert create_tx["attributes"]["label"] == "Sprint 1"
+    assert create_tx["attributes"]["status"] == 0  # planned
+    assert create_tx["attributes"]["targetDate"] is None
+
+
+def test_milestones_create_with_target_date_parses_to_ms():
+    """milestones create --target-date 2024-06-15 stores UTC ms in targetDate."""
+    find_mock = AsyncMock(return_value=PROJECT_DATA)
+    tx_mock = AsyncMock(return_value={})
+
+    with (
+        _auth_patch(),
+        patch("huly_cli.client.HulyClient.find_all", find_mock),
+        patch("huly_cli.client.HulyClient.tx", tx_mock),
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "milestones",
+                "create",
+                "--label",
+                "Sprint 1",
+                "--project",
+                "TP",
+                "--target-date",
+                "2024-06-15",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    create_tx = tx_mock.await_args.args[0]
+    assert create_tx["attributes"]["targetDate"] == 1718409600000
+
+
+def test_milestones_create_invalid_date_format_exits_nonzero():
+    """milestones create --target-date invalid surfaces a HulyError and exits 1."""
+    find_mock = AsyncMock(return_value=PROJECT_DATA)
+    tx_mock = AsyncMock(return_value={})
+
+    with (
+        _auth_patch(),
+        patch("huly_cli.client.HulyClient.find_all", find_mock),
+        patch("huly_cli.client.HulyClient.tx", tx_mock),
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "milestones",
+                "create",
+                "--label",
+                "Sprint 1",
+                "--project",
+                "TP",
+                "--target-date",
+                "not-a-date",
+            ],
+        )
+
+    assert result.exit_code == 1
+    assert "Invalid date" in result.output or "format" in result.output.lower()
+    tx_mock.assert_not_awaited()
+
+
+def test_milestones_create_invalid_status_exits_nonzero():
+    """milestones create with an unknown --status raises HulyError and exits 1."""
+    find_mock = AsyncMock(return_value=PROJECT_DATA)
+    tx_mock = AsyncMock(return_value={})
+
+    with (
+        _auth_patch(),
+        patch("huly_cli.client.HulyClient.find_all", find_mock),
+        patch("huly_cli.client.HulyClient.tx", tx_mock),
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "milestones",
+                "create",
+                "--label",
+                "Sprint 1",
+                "--project",
+                "TP",
+                "--status",
+                "bogus",
+            ],
+        )
+
+    assert result.exit_code == 1
+    tx_mock.assert_not_awaited()
+
+
+def test_milestones_create_project_not_found_exits_nonzero():
+    """milestones create exits with code 1 when the project identifier does not resolve."""
+    find_mock = AsyncMock(return_value=[])
+    tx_mock = AsyncMock(return_value={})
+
+    with (
+        _auth_patch(),
+        patch("huly_cli.client.HulyClient.find_all", find_mock),
+        patch("huly_cli.client.HulyClient.tx", tx_mock),
+    ):
+        result = runner.invoke(
+            app,
+            ["milestones", "create", "--label", "Sprint 1", "--project", "MISSING"],
+        )
+
+    assert result.exit_code == 1
+    tx_mock.assert_not_awaited()
+
+
+# ── milestones update ─────────────────────────────────────────────────────────
+
+
+def test_milestones_update_writes_update_doc_tx():
+    """milestones update applies provided fields as a TxUpdateDoc."""
+    tx_mock = AsyncMock(return_value={})
+
+    with (
+        _auth_patch(),
+        patch("huly_cli.client.HulyClient.find_all", new=AsyncMock(return_value=MILESTONE_DATA)),
+        patch("huly_cli.client.HulyClient.tx", tx_mock),
+    ):
+        result = runner.invoke(
+            app,
+            ["milestones", "update", "m1", "--label", "Renamed", "--status", "completed"],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "Milestone m1 updated." in result.output
+    update_tx = tx_mock.await_args.args[0]
+    assert update_tx["_class"] == "core:class:TxUpdateDoc"
+    assert update_tx["objectClass"] == "tracker:class:Milestone"
+    assert update_tx["objectSpace"] == "p1"
+    assert update_tx["objectId"] == "m1"
+    assert update_tx["operations"]["label"] == "Renamed"
+    assert update_tx["operations"]["status"] == 2  # completed
+
+
+def test_milestones_update_with_target_date_parses_to_ms():
+    """milestones update --target-date 2024-06-15 stores UTC ms in targetDate."""
+    tx_mock = AsyncMock(return_value={})
+
+    with (
+        _auth_patch(),
+        patch("huly_cli.client.HulyClient.find_all", new=AsyncMock(return_value=MILESTONE_DATA)),
+        patch("huly_cli.client.HulyClient.tx", tx_mock),
+    ):
+        result = runner.invoke(
+            app,
+            ["milestones", "update", "m1", "--target-date", "2024-06-15"],
+        )
+
+    assert result.exit_code == 0, result.output
+    update_tx = tx_mock.await_args.args[0]
+    assert update_tx["operations"]["targetDate"] == 1718409600000
+
+
+def test_milestones_update_invalid_date_format_exits_nonzero():
+    """milestones update --target-date invalid surfaces a HulyError and exits 1."""
+    tx_mock = AsyncMock(return_value={})
+
+    with (
+        _auth_patch(),
+        patch("huly_cli.client.HulyClient.find_all", new=AsyncMock(return_value=MILESTONE_DATA)),
+        patch("huly_cli.client.HulyClient.tx", tx_mock),
+    ):
+        result = runner.invoke(
+            app,
+            ["milestones", "update", "m1", "--target-date", "not-a-date"],
+        )
+
+    assert result.exit_code == 1
+    assert "Invalid date" in result.output or "format" in result.output.lower()
+    tx_mock.assert_not_awaited()
+
+
+def test_milestones_update_no_fields_warns_and_skips_tx():
+    """milestones update with no fields prints a warning and does not emit a tx."""
+    tx_mock = AsyncMock(return_value={})
+
+    with (
+        _auth_patch(),
+        patch("huly_cli.client.HulyClient.find_all", new=AsyncMock(return_value=MILESTONE_DATA)),
+        patch("huly_cli.client.HulyClient.tx", tx_mock),
+    ):
+        result = runner.invoke(app, ["milestones", "update", "m1"])
+
+    assert result.exit_code == 0, result.output
+    tx_mock.assert_not_awaited()
+
+
+def test_milestones_update_not_found_exits_nonzero():
+    """milestones update exits with code 1 when the milestone is not found."""
+    find_mock = AsyncMock(return_value=[])
+    tx_mock = AsyncMock(return_value={})
+
+    with (
+        _auth_patch(),
+        patch("huly_cli.client.HulyClient.find_all", find_mock),
+        patch("huly_cli.client.HulyClient.tx", tx_mock),
+    ):
+        result = runner.invoke(app, ["milestones", "update", "missing-id", "--label", "X"])
+
+    assert result.exit_code == 1
+    tx_mock.assert_not_awaited()
+
+
+# ── templates describe --set / --set-file ─────────────────────────────────────
+
+
+def _template_doc(**overrides):
+    base = {
+        "_id": "tmpl-1",
+        "title": "Bug Report",
+        "description": "",
+        "assignee": None,
+        "component": None,
+        "milestone": None,
+        "priority": 1,
+        "estimation": 0,
+        "children": [],
+        "comments": 0,
+        "attachments": 0,
+        "labels": 0,
+        "kind": "",
+        "relations": [],
+        "space": "p1",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_templates_describe_set_writes_inline_prosemirror_dict():
+    """templates describe --set converts markdown to an inline ProseMirror dict via TxUpdateDoc."""
+    tx_mock = AsyncMock(return_value={})
+    template_doc = _template_doc(description="")
+
+    with (
+        _auth_patch(),
+        patch(
+            "huly_cli.client.HulyClient.find_all",
+            new=AsyncMock(return_value=[template_doc]),
+        ),
+        patch("huly_cli.client.HulyClient.tx", tx_mock),
+    ):
+        result = runner.invoke(
+            app,
+            ["templates", "describe", "tmpl-1", "--set", "Hello world"],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "Description updated" in result.output
+    update_tx = tx_mock.await_args.args[0]
+    assert update_tx["_class"] == "core:class:TxUpdateDoc"
+    assert update_tx["objectClass"] == "tracker:class:IssueTemplate"
+    assert update_tx["objectSpace"] == "p1"
+    assert update_tx["objectId"] == "tmpl-1"
+    # Description is stored as an inline ProseMirror dict, not a blob ref string
+    description = update_tx["operations"]["description"]
+    assert isinstance(description, dict)
+    assert description.get("type") == "doc"
+
+
+def test_templates_describe_set_aborts_on_blob_ref_heuristic():
+    """templates describe --set refuses to overwrite a description that looks like a blob ref."""
+    tx_mock = AsyncMock(return_value={})
+    # Description contains "-description-" → blob-ref heuristic should trip
+    template_doc = _template_doc(description="abc-description-xyz")
+
+    with (
+        _auth_patch(),
+        patch(
+            "huly_cli.client.HulyClient.find_all",
+            new=AsyncMock(return_value=[template_doc]),
+        ),
+        patch("huly_cli.client.HulyClient.tx", tx_mock),
+    ):
+        result = runner.invoke(
+            app,
+            ["templates", "describe", "tmpl-1", "--set", "Hello world"],
+        )
+
+    assert result.exit_code == 1
+    assert "blob ref" in result.output.lower() or "corruption" in result.output.lower()
+    tx_mock.assert_not_awaited()
+
+
+def test_templates_describe_set_file_reads_from_disk_and_writes(tmp_path):
+    """templates describe --set-file reads markdown from disk and writes inline ProseMirror."""
+    tx_mock = AsyncMock(return_value={})
+    md_file = tmp_path / "body.md"
+    md_file.write_text("# Heading\n\nBody text.", encoding="utf-8")
+
+    template_doc = _template_doc(description="")
+
+    with (
+        _auth_patch(),
+        patch(
+            "huly_cli.client.HulyClient.find_all",
+            new=AsyncMock(return_value=[template_doc]),
+        ),
+        patch("huly_cli.client.HulyClient.tx", tx_mock),
+    ):
+        result = runner.invoke(
+            app,
+            ["templates", "describe", "tmpl-1", "--set-file", str(md_file)],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "Description updated" in result.output
+    description = tx_mock.await_args.args[0]["operations"]["description"]
+    assert isinstance(description, dict)
+    assert description.get("type") == "doc"
+
+
+def test_templates_describe_set_file_missing_exits_nonzero():
+    """templates describe --set-file exits 1 when the source file does not exist."""
+    tx_mock = AsyncMock(return_value={})
+
+    with (
+        _auth_patch(),
+        patch(
+            "huly_cli.client.HulyClient.find_all",
+            new=AsyncMock(return_value=[_template_doc()]),
+        ),
+        patch("huly_cli.client.HulyClient.tx", tx_mock),
+    ):
+        result = runner.invoke(
+            app,
+            ["templates", "describe", "tmpl-1", "--set-file", "/nonexistent/path.md"],
+        )
+
+    assert result.exit_code == 1
+    assert "not found" in result.output.lower()
+    tx_mock.assert_not_awaited()
+
+
+def test_templates_describe_rejects_both_set_and_set_file():
+    """Passing both --set and --set-file should error out before any IO."""
+    result = runner.invoke(
+        app,
+        [
+            "templates",
+            "describe",
+            "tmpl-1",
+            "--set",
+            "x",
+            "--set-file",
+            "/tmp/whatever.md",
+        ],
+    )
+    assert result.exit_code == 1
+    assert "either" in result.output.lower() or "not both" in result.output.lower()
+
+
+def test_templates_describe_set_not_found_exits_nonzero():
+    """templates describe --set exits with code 1 when the template is not found."""
+    tx_mock = AsyncMock(return_value={})
+
+    with (
+        _auth_patch(),
+        patch("huly_cli.client.HulyClient.find_all", new=AsyncMock(return_value=[])),
+        patch("huly_cli.client.HulyClient.tx", tx_mock),
+    ):
+        result = runner.invoke(
+            app,
+            ["templates", "describe", "missing-id", "--set", "x"],
+        )
+
+    assert result.exit_code == 1
+    tx_mock.assert_not_awaited()

--- a/tests/test_issue_write_path.py
+++ b/tests/test_issue_write_path.py
@@ -115,6 +115,104 @@ async def test_create_impl_increments_project_sequence_and_uses_blob_ref(fake_co
     create_description_mock.assert_awaited_once()
 
 
+async def test_create_impl_falls_back_to_inline_markup_when_blob_create_fails(
+    fake_config, fake_auth
+):
+    """When create_description returns None, _create_impl writes inline ProseMirror markup."""
+    project_doc = {
+        "_id": "project-1",
+        "name": "My Project",
+        "identifier": "DEMO",
+        "sequence": 16,
+        "members": [],
+        "owners": [],
+        "description": "",
+        "defaultIssueStatus": "tracker:status:Backlog",
+        "private": False,
+        "archived": False,
+    }
+    find_all_mock = AsyncMock(
+        side_effect=[
+            [project_doc],
+            [{"_id": "issue-16", "rank": "0|i0002f:", "space": "project-1"}],
+        ]
+    )
+    tx_mock = AsyncMock(side_effect=[{"object": {"sequence": 17}}, {}, {}])
+    # create_description returns None → fallback to inline markup
+    create_description_mock = AsyncMock(return_value=None)
+
+    with (
+        patch("huly_cli.commands.issues.ensure_auth", new=AsyncMock(return_value=fake_auth)),
+        patch("huly_cli.client.HulyClient.find_all", find_all_mock),
+        patch("huly_cli.client.HulyClient.tx", tx_mock),
+        patch("huly_cli.client.HulyClient.create_description", create_description_mock),
+    ):
+        message = await issues_cmd._create_impl(
+            fake_config,
+            title="Fix auth drift",
+            project="DEMO",
+            status=None,
+            priority="high",
+            assignee=None,
+            description="# Heading",
+        )
+
+    description_tx = tx_mock.await_args_list[2].args[0]
+    description_value = description_tx["operations"]["description"]
+    # Fallback should write inline ProseMirror JSON, not a blob ref
+    assert isinstance(description_value, str)
+    assert description_value.startswith("{")
+    assert "doc" in description_value  # the ProseMirror dict has a "doc" type
+    assert "DEMO-17" in message
+    create_description_mock.assert_awaited_once()
+
+
+async def test_create_impl_skips_description_tx_when_no_description_provided(
+    fake_config, fake_auth
+):
+    """When description is None/empty, _create_impl should only emit increment + create txs."""
+    project_doc = {
+        "_id": "project-1",
+        "name": "My Project",
+        "identifier": "DEMO",
+        "sequence": 16,
+        "members": [],
+        "owners": [],
+        "description": "",
+        "defaultIssueStatus": "tracker:status:Backlog",
+        "private": False,
+        "archived": False,
+    }
+    find_all_mock = AsyncMock(
+        side_effect=[
+            [project_doc],
+            [{"_id": "issue-16", "rank": "0|i0002f:", "space": "project-1"}],
+        ]
+    )
+    tx_mock = AsyncMock(side_effect=[{"object": {"sequence": 17}}, {}])
+    create_description_mock = AsyncMock(return_value="blob-description-x")
+
+    with (
+        patch("huly_cli.commands.issues.ensure_auth", new=AsyncMock(return_value=fake_auth)),
+        patch("huly_cli.client.HulyClient.find_all", find_all_mock),
+        patch("huly_cli.client.HulyClient.tx", tx_mock),
+        patch("huly_cli.client.HulyClient.create_description", create_description_mock),
+    ):
+        await issues_cmd._create_impl(
+            fake_config,
+            title="No description",
+            project="DEMO",
+            status=None,
+            priority="medium",
+            assignee=None,
+            description=None,
+        )
+
+    # Only two tx calls: increment, then create (no description tx)
+    assert tx_mock.await_count == 2
+    create_description_mock.assert_not_awaited()
+
+
 async def test_update_impl_resolves_custom_status_and_unassigns(fake_config, fake_auth):
     issue = Issue.model_validate(_raw_issue(space="project-1"))
     tx_mock = AsyncMock(return_value={})


### PR DESCRIPTION
## Summary

Adds tests for six commands/paths that had zero test coverage, identified during a bug sweep.

### Coverage added

- **`auth login` / `auth status`** — happy path, missing credentials, stale cache
- **`projects get`** — found by identifier, not found
- **`milestones create` / `milestones update`** — happy path, invalid date format, `_parse_date_ms` edge cases
- **`components create` / `components update`** — happy path, not found
- **`templates describe --set` / `--set-file`** — write path including blob-ref detection heuristic
- **`issues create` fallback** — `create_description` returns `None`, falls back to inline markup

No production code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)