### PR TITLE
fix: allow null values for Issue, Person, PersonAccount, and TagReference fields

### DIFF
--- a/src/huly_cli/commands/components.py
+++ b/src/huly_cli/commands/components.py
@@ -40,7 +40,7 @@ async def _fetch_person_map(client: HulyClient) -> dict[str, str]:
     raw = await client.find_all("contact:class:Person", options={"limit": 500})
     result: dict[str, str] = {}
     for p in raw:
-        name: str = p.get("name", "")
+        name: str = p.get("name") or ""
         parts = name.split(",", 1)
         display = f"{parts[1].strip()} {parts[0].strip()}" if len(parts) == 2 else name
         result[p["_id"]] = display
@@ -52,7 +52,7 @@ async def _resolve_person_by_name(client: HulyClient, name: str) -> str:
     persons = await client.find_all("contact:class:Person", options={"limit": 500})
     query_lower = name.lower()
     for p in persons:
-        raw_name: str = p.get("name", "")
+        raw_name: str = p.get("name") or ""
         parts = raw_name.split(",", 1)
         display = f"{parts[1].strip()} {parts[0].strip()}" if len(parts) == 2 else raw_name
         if query_lower in display.lower() or query_lower in raw_name.lower():

--- a/src/huly_cli/commands/issues.py
+++ b/src/huly_cli/commands/issues.py
@@ -104,7 +104,7 @@ async def _resolve_person_by_name(client: HulyClient, name: str) -> str:
     needle = name.lower()
     for doc in raw:
         person = Person.model_validate(doc)
-        if needle in person.display_name.lower() or needle in person.name.lower():
+        if needle in person.display_name.lower() or needle in (person.name or "").lower():
             return person.id
     raise NotFoundError(f"Person '{name}' not found.")
 

--- a/src/huly_cli/commands/labels.py
+++ b/src/huly_cli/commands/labels.py
@@ -39,15 +39,15 @@ def labels_list(ctx: typer.Context) -> None:
         counts: Counter[str] = Counter(t.title for t in tags)
 
         # Deduplicate by title, sorted alphabetically
-        seen: set[str] = set()
+        seen: set[str | None] = set()
         rows: list[dict[str, Any]] = []
-        for t in sorted(tags, key=lambda x: x.title.lower()):
+        for t in sorted(tags, key=lambda x: (x.title or "").lower()):
             if t.title in seen:
                 continue
             seen.add(t.title)
             rows.append(
                 {
-                    "title": t.title,
+                    "title": t.title or "",
                     "count": str(counts[t.title]),
                 }
             )

--- a/src/huly_cli/models.py
+++ b/src/huly_cli/models.py
@@ -50,9 +50,9 @@ class Issue(BaseModel):
     kind: str = ""
     assignee: str | None = None
     due_date: int | None = Field(None, alias="dueDate")
-    created_by: str = Field("", alias="createdBy")
+    created_by: str | None = Field(None, alias="createdBy")
     created_on: int = Field(0, alias="createdOn")
-    modified_by: str = Field("", alias="modifiedBy")
+    modified_by: str | None = Field(None, alias="modifiedBy")
     modified_on: int = Field(0, alias="modifiedOn")
     estimation: int = 0
     labels: Any = 0
@@ -88,10 +88,12 @@ class Person(BaseModel):
     model_config = {"populate_by_name": True}
 
     id: str = Field(alias="_id")
-    name: str  # "LastName,FirstName"
+    name: str | None = None  # "LastName,FirstName"
 
     @property
     def display_name(self) -> str:
+        if not self.name:
+            return ""
         parts = self.name.split(",", 1)
         return f"{parts[1].strip()} {parts[0].strip()}" if len(parts) == 2 else self.name
 
@@ -106,14 +108,14 @@ class PersonAccount(BaseModel):
 
     id: str = Field(alias="_id")  # Account ID
     person: str  # Person ID (Ref to contact:class:Person)
-    email: str = ""
+    email: str | None = None
 
 
 class TagReference(BaseModel):
     model_config = {"populate_by_name": True}
 
-    tag: str
-    title: str
+    tag: str | None = None
+    title: str | None = None
     attached_to: str = Field("", alias="attachedTo")
 
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -154,6 +154,39 @@ def test_issues_list_empty():
     assert result.exit_code == 0
 
 
+def test_issues_list_handles_null_person_name():
+    """issues list must not crash when a workspace person has name=None."""
+    issue_with_assignee = [
+        {
+            "_id": "i2",
+            "title": "Null name issue",
+            "identifier": "TP-2",
+            "number": 2,
+            "status": "tracker:status:Backlog",
+            "priority": 0,
+            "assignee": "person-null",
+            "description": "",
+            "kind": "",
+            "createdBy": "",
+            "createdOn": 0,
+            "modifiedBy": "",
+            "modifiedOn": 0,
+            "estimation": 0,
+            "labels": 0,
+            "comments": 0,
+            "subIssues": 0,
+            "space": "p1",
+            "dueDate": None,
+        }
+    ]
+    persons_with_null_name = [{"_id": "person-null", "name": None}]
+    find_mock = AsyncMock(side_effect=[issue_with_assignee, persons_with_null_name])
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["issues", "list"])
+    assert result.exit_code == 0, result.output
+    assert "Null name issue" in result.output
+
+
 # ── members list ───────────────────────────────────────────────────────────────
 
 
@@ -257,6 +290,19 @@ def test_labels_list_empty():
     with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
         result = runner.invoke(app, ["labels", "list"])
     assert result.exit_code == 0
+
+
+def test_labels_list_handles_null_title():
+    """labels list must not crash when a TagReference has title=None."""
+    tag_data = [
+        {"_id": "t1", "tag": "tag1", "title": "Real Label", "attachedTo": "i1"},
+        {"_id": "t2", "tag": "tag2", "title": None, "attachedTo": "i2"},
+    ]
+    find_mock = AsyncMock(return_value=tag_data)
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["labels", "list"])
+    assert result.exit_code == 0, result.output
+    assert "Real Label" in result.output
 
 
 # ── JSON output mode ───────────────────────────────────────────────────────────
@@ -389,6 +435,29 @@ def test_components_list_empty():
     with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
         result = runner.invoke(app, ["components", "list"])
     assert result.exit_code == 0
+
+
+def test_components_list_handles_null_person_name():
+    """components list must not crash when a person in the API response has name=None."""
+    component_with_lead = [
+        {
+            "_id": "c2",
+            "label": "Null Lead Component",
+            "description": "Has a lead with null name",
+            "lead": "person-null",
+            "space": "proj1",
+            "createdBy": "",
+            "createdOn": 0,
+            "modifiedBy": "",
+            "modifiedOn": 0,
+        }
+    ]
+    persons_with_null_name = [{"_id": "person-null", "name": None}]
+    find_mock = AsyncMock(side_effect=[component_with_lead, persons_with_null_name])
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["components", "list"])
+    assert result.exit_code == 0, result.output
+    assert "Null Lead Component" in result.output
 
 
 def test_components_list_shows_description():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -98,6 +98,18 @@ class TestIssue:
         issue = Issue.model_validate(raw)
         assert issue.created_by == "user1"
 
+    def test_issue_accepts_null_created_by(self):
+        """Regression test for issue #16: API may return null for createdBy."""
+        raw = {"_id": "x", "title": "T", "createdBy": None}
+        issue = Issue.model_validate(raw)
+        assert issue.created_by is None
+
+    def test_issue_accepts_null_modified_by(self):
+        """Regression test for issue #16: API may return null for modifiedBy."""
+        raw = {"_id": "x", "title": "T", "modifiedBy": None}
+        issue = Issue.model_validate(raw)
+        assert issue.modified_by is None
+
 
 # ── Person ─────────────────────────────────────────────────────────────────────
 
@@ -119,6 +131,16 @@ class TestPerson:
         p = Person.model_validate({"_id": "person-id-123", "name": "Doe,Jane"})
         assert p.id == "person-id-123"
         assert p.display_name == "Jane Doe"
+
+    def test_person_accepts_null_name(self):
+        """Regression test for issue #16: API may return null for name."""
+        p = Person.model_validate({"_id": "p4", "name": None})
+        assert p.name is None
+
+    def test_person_display_name_with_null_name(self):
+        """Regression test for issue #16: display_name must not crash on None."""
+        p = Person.model_validate({"_id": "p5", "name": None})
+        assert p.display_name == ""
 
 
 # ── Project ────────────────────────────────────────────────────────────────────
@@ -165,7 +187,13 @@ class TestPersonAccount:
     def test_person_account_default_email(self):
         raw = {"_id": "acc2", "person": "person2"}
         acc = PersonAccount.model_validate(raw)
-        assert acc.email == ""
+        assert acc.email is None
+
+    def test_person_account_accepts_null_email(self):
+        """Regression test for issue #16: API may return null for email."""
+        raw = {"_id": "acc3", "person": "person3", "email": None}
+        acc = PersonAccount.model_validate(raw)
+        assert acc.email is None
 
 
 # ── TagReference ───────────────────────────────────────────────────────────────
@@ -184,6 +212,18 @@ class TestTagReference:
         raw = {"tag": "t", "title": "Label"}
         tag = TagReference.model_validate(raw)
         assert tag.attached_to == ""
+
+    def test_tag_reference_accepts_null_tag(self):
+        """Regression test for issue #16: API may return null for tag."""
+        raw = {"tag": None, "title": "Label"}
+        tag = TagReference.model_validate(raw)
+        assert tag.tag is None
+
+    def test_tag_reference_accepts_null_title(self):
+        """Regression test for issue #16: API may return null for title."""
+        raw = {"tag": "t", "title": None}
+        tag = TagReference.model_validate(raw)
+        assert tag.title is None
 
 
 # ── Dict constants ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes the same class of bug as #11: multiple Pydantic model fields typed as plain `str` crash with `ValidationError` when the API returns `null`.

## Fields changed

| Model | Field | Old type | New type |
|---|---|---|---|
| `Issue` | `created_by` / `modified_by` | `str` | `str \| None` |
| `Person` | `name` | `str` (required) | `str \| None` |
| `PersonAccount` | `email` | `str` | `str \| None` |
| `TagReference` | `tag` / `title` | `str` (required) | `str \| None` |

## Downstream None-safety

- `Person.display_name` returns `""` when `name` is `None` instead of crashing.
- `issues.py` `_resolve_person_by_name` guards `person.name.lower()` against `None`.
- `labels.py` guards title sort/dedup/row-build against `None` titles.
- `components.py` `_fetch_person_map` / `_resolve_person_by_name` coerce raw `None` names from the API to `""`.

## Trigger conditions

- Issues imported from external trackers (author account absent)
- SSO / OAuth accounts with no email record
- Any automation-created issue where `createdBy` is not populated

## Testing

Regression tests added for each field following the pattern established in #11. Existing `test_person_account_default_email` updated to expect `None` (consistent with the new default).

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)