### PR TITLE
fix: raise AuthError instead of KeyError on unexpected login response

### DIFF
--- a/src/huly_cli/auth.py
+++ b/src/huly_cli/auth.py
@@ -38,9 +38,21 @@ async def login(config: HulyConfig) -> AuthCache:
         )
         resp.raise_for_status()
         body = resp.json()
-        if "error" in body:
+        if "error" in body and body["error"] is not None:
             raise AuthError(f"Login failed: {body['error']}")
-        account_token: str = body["result"]["token"]
+        if "result" not in body or not isinstance(body.get("result"), dict):
+            raise AuthError(
+                "Login failed: unexpected response from accounts API "
+                "(missing 'result' field). The server may be incompatible "
+                "or a proxy may be intercepting the request."
+            )
+        account_token_value = body["result"].get("token")
+        if not account_token_value or not isinstance(account_token_value, str):
+            raise AuthError(
+                "Login failed: accounts API response did not include a 'token' "
+                "in the 'result' payload."
+            )
+        account_token: str = account_token_value
 
         # Step 2: Select workspace
         resp = await http.post(
@@ -54,11 +66,28 @@ async def login(config: HulyConfig) -> AuthCache:
         )
         resp.raise_for_status()
         body = resp.json()
-        if "error" in body:
+        if "error" in body and body["error"] is not None:
             raise AuthError(f"Select workspace failed: {body['error']}")
+        if "result" not in body or not isinstance(body.get("result"), dict):
+            raise AuthError(
+                "Select workspace failed: unexpected response from accounts API "
+                "(missing 'result' field)."
+            )
         ws_result = body["result"]
-        workspace_token: str = ws_result["token"]
-        workspace_id: str = ws_result["workspaceId"]
+        workspace_token_value = ws_result.get("token")
+        workspace_id_value = ws_result.get("workspaceId")
+        if not workspace_token_value or not isinstance(workspace_token_value, str):
+            raise AuthError(
+                "Select workspace failed: response did not include a 'token' "
+                "in the 'result' payload."
+            )
+        if not workspace_id_value or not isinstance(workspace_id_value, str):
+            raise AuthError(
+                "Select workspace failed: response did not include a 'workspaceId' "
+                "in the 'result' payload."
+            )
+        workspace_token: str = workspace_token_value
+        workspace_id: str = workspace_id_value
 
         # Step 3: Get workspace UUID via getUserWorkspaces
         resp = await http.post(
@@ -68,10 +97,10 @@ async def login(config: HulyConfig) -> AuthCache:
         )
         resp.raise_for_status()
         body = resp.json()
-        if "error" in body:
+        if "error" in body and body["error"] is not None:
             raise AuthError(f"getUserWorkspaces failed: {body['error']}")
         workspace_uuid = ""
-        for ws in body.get("result", []):
+        for ws in body.get("result", []) or []:
             if ws.get("workspaceUrl") == config.workspace:
                 workspace_uuid = ws.get("uuid", "")
                 break

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,100 @@
+"""Unit tests for `huly_cli.auth` covering malformed API responses.
+
+Regression tests for issue #18: the login flow previously raised
+a raw ``KeyError: 'result'`` when the accounts API returned an
+unexpected ``200 OK`` body. These tests assert that a descriptive
+``AuthError`` is raised instead.
+"""
+
+from __future__ import annotations
+
+import pytest
+import respx
+
+from huly_cli import auth as auth_module
+from huly_cli.errors import AuthError
+
+
+ACCOUNTS_URL = "https://test.example.com/_accounts"
+
+
+async def test_login_raises_auth_error_when_result_missing(fake_config):
+    """Login 200 response without a 'result' key should raise AuthError, not KeyError."""
+    with respx.mock:
+        respx.post(ACCOUNTS_URL).respond(json={})
+
+        with pytest.raises(AuthError) as exc_info:
+            await auth_module.login(fake_config)
+
+    message = str(exc_info.value)
+    assert "result" in message.lower()
+    assert "KeyError" not in type(exc_info.value).__name__
+
+
+async def test_login_raises_auth_error_when_result_has_no_token(fake_config):
+    """Login 200 response where result lacks 'token' should raise AuthError, not KeyError."""
+    with respx.mock:
+        respx.post(ACCOUNTS_URL).respond(json={"result": {}})
+
+        with pytest.raises(AuthError) as exc_info:
+            await auth_module.login(fake_config)
+
+    message = str(exc_info.value)
+    assert "token" in message.lower()
+
+
+async def test_login_raises_auth_error_when_error_null_and_no_result(fake_config):
+    """An {'error': null} 200 body is still a malformed login response → AuthError."""
+    with respx.mock:
+        respx.post(ACCOUNTS_URL).respond(json={"error": None})
+
+        with pytest.raises(AuthError):
+            await auth_module.login(fake_config)
+
+
+async def test_login_raises_auth_error_when_select_workspace_missing_token(fake_config):
+    """selectWorkspace response missing 'token' should raise AuthError, not KeyError."""
+    with respx.mock:
+        # respx matches routes in registration order and returns the first match;
+        # we use a side_effect to return different bodies for successive calls.
+        call_count = {"n": 0}
+
+        def handler(request):
+            import httpx as _httpx
+
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                # login succeeds
+                return _httpx.Response(200, json={"result": {"token": "acct-tok"}})
+            # selectWorkspace returns body without token/workspaceId
+            return _httpx.Response(200, json={"result": {}})
+
+        respx.post(ACCOUNTS_URL).mock(side_effect=handler)
+
+        with pytest.raises(AuthError) as exc_info:
+            await auth_module.login(fake_config)
+
+    message = str(exc_info.value).lower()
+    assert "token" in message or "workspaceid" in message or "workspace" in message
+
+
+async def test_login_raises_auth_error_when_select_workspace_missing_result(fake_config):
+    """selectWorkspace response without 'result' should raise AuthError, not KeyError."""
+    with respx.mock:
+        call_count = {"n": 0}
+
+        def handler(request):
+            import httpx as _httpx
+
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                return _httpx.Response(200, json={"result": {"token": "acct-tok"}})
+            # selectWorkspace: no 'result' key
+            return _httpx.Response(200, json={})
+
+        respx.post(ACCOUNTS_URL).mock(side_effect=handler)
+
+        with pytest.raises(AuthError) as exc_info:
+            await auth_module.login(fake_config)
+
+    assert "result" in str(exc_info.value).lower()

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -14,7 +14,6 @@ import respx
 from huly_cli import auth as auth_module
 from huly_cli.errors import AuthError
 
-
 ACCOUNTS_URL = "https://test.example.com/_accounts"
 
 


### PR DESCRIPTION
## Summary

`huly auth login` was crashing with a raw `KeyError: 'result'` when the accounts API returned a `200 OK` response with an unexpected body shape, producing the opaque message `Login failed: 'result'`.

## Root Cause

`auth.py` used bare `body["result"]["token"]` after only checking for an `"error"` key. Any valid JSON response lacking the `"result"` key (API version mismatch, intercepting proxy, degraded server) caused an unguarded `KeyError`.

## Fix

Added explicit key-presence checks at each API response access point. Missing expected keys now raise `AuthError` with a descriptive message instead of propagating a raw `KeyError`.

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)