### PR TITLE
fix: correct Retry-After handling and drop non-dict find_all items

### DIFF
--- a/src/huly_cli/client.py
+++ b/src/huly_cli/client.py
@@ -275,11 +275,20 @@ class HulyClient:
                 f"Authentication failed (HTTP {resp.status_code}). Run 'huly auth login'."
             )
         if resp.status_code == 429:
-            retry_after = float(
-                resp.headers.get("Retry-After") or resp.headers.get("Retry-After-ms", 0)
-            )
-            if retry_after > 1000:
-                retry_after /= 1000  # convert ms to seconds
+            # RFC 7231: `Retry-After` is in seconds (or an HTTP-date, unsupported
+            # here). Only the explicitly millisecond-based `Retry-After-ms`
+            # header should be converted — never guess based on magnitude.
+            retry_after_header = resp.headers.get("Retry-After")
+            if retry_after_header is not None:
+                try:
+                    retry_after = float(retry_after_header)
+                except ValueError:
+                    retry_after = 0.0
+            else:
+                try:
+                    retry_after = float(resp.headers.get("Retry-After-ms", 0)) / 1000.0
+                except ValueError:
+                    retry_after = 0.0
             raise RateLimitError("Rate limit exceeded.", retry_after=retry_after)
         if resp.status_code >= 500:
             raise ServerError(f"Server error (HTTP {resp.status_code}): {resp.text[:200]}")
@@ -311,10 +320,13 @@ class HulyClient:
         if not isinstance(rows, list):
             return []
 
+        # Filter out any non-dict entries (e.g. ``None``) up front so callers
+        # never see them. Keeping them in the list caused
+        # ``Model.model_validate`` to raise ``ValidationError`` on null rows.
+        rows = [row for row in rows if isinstance(row, dict)]
+
         if isinstance(lookup_map, dict):
             for row in rows:
-                if not isinstance(row, dict):
-                    continue
                 lookup = row.get("$lookup")
                 if not isinstance(lookup, dict):
                     continue
@@ -325,8 +337,6 @@ class HulyClient:
                         lookup[key] = lookup_map.get(value)
 
         for row in rows:
-            if not isinstance(row, dict):
-                continue
             if row.get("_class") is None:
                 row["_class"] = class_id
             for key, value in query.items():

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -299,3 +299,72 @@ async def test_collaborator_rpc_retries_create_content(fake_config, fake_auth, m
             ref = await client.create_description("issue1", '{"type":"doc"}')
     assert ref == "blob-new"
     assert call_count == 3
+
+
+# ── Retry-After header handling (Bug A) ──────────────────────────────────────
+
+
+async def test_rate_limit_retry_after_large_seconds_not_converted(fake_config, fake_auth):
+    """Retry-After: 1500 is valid seconds per RFC 7231, must NOT be divided by 1000.
+
+    Regression test for Issue #20 Bug A: the `> 1000` heuristic silently converted
+    a legitimate 1500-second wait into 1.5 seconds.
+    """
+    with respx.mock:
+        respx.post("https://test.example.com/_transactor/api/v1/find-all/w-test-123").respond(
+            429, headers={"Retry-After": "1500"}
+        )
+        async with HulyClient(fake_config, fake_auth) as client:
+            with pytest.raises(RateLimitError) as exc_info:
+                await client.find_all("tracker:class:Issue")
+    # Must be treated as seconds per RFC 7231, not milliseconds.
+    assert exc_info.value.retry_after == 1500.0
+
+
+async def test_rate_limit_retry_after_small_seconds_unchanged(fake_config, fake_auth):
+    """Retry-After: 500 is 500 seconds, must NOT be reinterpreted as ms."""
+    with respx.mock:
+        respx.post("https://test.example.com/_transactor/api/v1/find-all/w-test-123").respond(
+            429, headers={"Retry-After": "500"}
+        )
+        async with HulyClient(fake_config, fake_auth) as client:
+            with pytest.raises(RateLimitError) as exc_info:
+                await client.find_all("tracker:class:Issue")
+    assert exc_info.value.retry_after == 500.0
+
+
+# ── find_all filters non-dict rows (Bug B) ───────────────────────────────────
+
+
+async def test_find_all_drops_null_rows(fake_config, fake_auth):
+    """Non-dict rows (e.g. null) in the server response must be filtered out.
+
+    Regression test for Issue #20 Bug B: the normalisation loop used `continue`
+    to skip non-dicts but left them in the returned list, causing
+    Model.model_validate(None) ValidationError downstream.
+    """
+    with respx.mock:
+        respx.post("https://test.example.com/_transactor/api/v1/find-all/w-test-123").respond(
+            json={"value": [None, {"_id": "x", "name": "real"}], "total": -1}
+        )
+        async with HulyClient(fake_config, fake_auth) as client:
+            result = await client.find_all("tracker:class:Issue")
+    # Only the dict row should survive — the `None` must be dropped, not kept.
+    assert len(result) == 1
+    assert all(isinstance(row, dict) for row in result)
+    assert result[0]["_id"] == "x"
+
+
+async def test_find_all_drops_mixed_non_dict_rows(fake_config, fake_auth):
+    """Mixed non-dict items (null, string, int) must all be filtered out."""
+    with respx.mock:
+        respx.post("https://test.example.com/_transactor/api/v1/find-all/w-test-123").respond(
+            json={
+                "value": [None, "stray-string", 42, {"_id": "keep", "name": "real"}],
+                "total": -1,
+            }
+        )
+        async with HulyClient(fake_config, fake_auth) as client:
+            result = await client.find_all("tracker:class:Issue")
+    assert len(result) == 1
+    assert result[0]["_id"] == "keep"


### PR DESCRIPTION
## Summary

Two edge-case bugs in `client.py`.

### Bug A — `Retry-After` heuristic misfires

The `> 1000` division heuristic misidentified large second values as milliseconds (e.g. `Retry-After: 1500` was converted to 1.5 s instead of 1500 s). Fixed by treating `Retry-After` as seconds per RFC 7231 and removing the heuristic. The explicitly millisecond-based `Retry-After-ms` fallback is still honoured when `Retry-After` is absent.

### Bug B — Non-dict items in `find_all` result survive normalisation

The normalisation loop used `continue` to skip `null` / non-dict items but left them in the returned list. Callers passing the list to `Model.model_validate()` received a `ValidationError` on `None`. Fixed by filtering non-dict items out of the result before returning.

Closes #20

## Test plan

- [x] `test_rate_limit_retry_after_large_seconds_not_converted` — `Retry-After: 1500` yields `retry_after == 1500.0` (not 1.5)
- [x] `test_rate_limit_retry_after_small_seconds_unchanged` — `Retry-After: 500` yields `retry_after == 500.0`
- [x] `test_find_all_drops_null_rows` — response with `null` in `value` returns list of length 1
- [x] `test_find_all_drops_mixed_non_dict_rows` — null/string/int rows all filtered out
- [x] Full suite: 231 passed
- [x] `ruff check` + `ruff format --check` clean

Generated with [Claude Code](https://claude.com/claude-code)