### PR TITLE
fix: use identity check for --set/--set-file mutual exclusion

### DIFF
--- a/src/huly_cli/commands/documents.py
+++ b/src/huly_cli/commands/documents.py
@@ -313,7 +313,7 @@ def docs_describe(
 
     By default, reads and displays the content. Use --set or --set-file to write.
     """
-    if set_text and set_file:
+    if set_text is not None and set_file is not None:
         print_error("Use either --set or --set-file, not both.")
         raise typer.Exit(1)
 

--- a/src/huly_cli/commands/issues.py
+++ b/src/huly_cli/commands/issues.py
@@ -572,7 +572,7 @@ def issues_describe(
 
     By default, reads and displays the description. Use --set or --set-file to write.
     """
-    if set_text and set_file:
+    if set_text is not None and set_file is not None:
         print_error("Use either --set or --set-file, not both.")
         raise typer.Exit(1)
 

--- a/src/huly_cli/commands/templates.py
+++ b/src/huly_cli/commands/templates.py
@@ -177,7 +177,7 @@ def templates_describe(
     Template descriptions are stored as inline ProseMirror JSON (not a blob ref).
     By default, reads and displays the description. Use --set or --set-file to write.
     """
-    if set_text and set_file:
+    if set_text is not None and set_file is not None:
         print_error("Use either --set or --set-file, not both.")
         raise typer.Exit(1)
 

--- a/tests/test_issue_write_path.py
+++ b/tests/test_issue_write_path.py
@@ -637,3 +637,49 @@ def test_issues_list_status_unknown_in_live_index_raises(fake_auth):
     assert result.exit_code == 1
     assert "Unknown status" in result.output
     assert "no-such-status" in result.output
+
+
+def test_issues_describe_rejects_set_and_set_file(tmp_path):
+    """Regression for #21: passing both --set "" and --set-file must error out.
+
+    An empty string for --set is falsy, so a truthiness check silently bypasses
+    the mutual-exclusion guard. The guard must use an identity check.
+    """
+    tmpfile = tmp_path / "body.md"
+    tmpfile.write_text("from file", encoding="utf-8")
+
+    result = runner.invoke(
+        app,
+        ["issues", "describe", "DEMO-1", "--set", "", "--set-file", str(tmpfile)],
+    )
+
+    assert result.exit_code != 0, result.output
+    assert "Use either --set or --set-file, not both." in result.output
+
+
+def test_documents_describe_rejects_set_and_set_file(tmp_path):
+    """Regression for #21: passing both --set "" and --set-file must error out."""
+    tmpfile = tmp_path / "body.md"
+    tmpfile.write_text("from file", encoding="utf-8")
+
+    result = runner.invoke(
+        app,
+        ["documents", "describe", "doc-1", "--set", "", "--set-file", str(tmpfile)],
+    )
+
+    assert result.exit_code != 0, result.output
+    assert "Use either --set or --set-file, not both." in result.output
+
+
+def test_templates_describe_rejects_set_and_set_file(tmp_path):
+    """Regression for #21: passing both --set "" and --set-file must error out."""
+    tmpfile = tmp_path / "body.md"
+    tmpfile.write_text("from file", encoding="utf-8")
+
+    result = runner.invoke(
+        app,
+        ["templates", "describe", "tmpl-1", "--set", "", "--set-file", str(tmpfile)],
+    )
+
+    assert result.exit_code != 0, result.output
+    assert "Use either --set or --set-file, not both." in result.output


### PR DESCRIPTION
## Summary

`--set ""` combined with `--set-file <path>` was silently accepted in `issues describe`, `documents describe`, and `templates describe`. The empty-string intent was discarded and the file content won with no error or warning.

## Root Cause

The mutual-exclusion guard used a truthiness check (`if set_text and set_file`). An empty string is falsy, so the guard was bypassed when `--set ""` was passed alongside `--set-file`.

## Fix

Changed all three guards to identity checks (`if set_text is not None and set_file is not None`), so the error is raised regardless of whether `--set` is empty or non-empty.

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)