### PR TITLE
feat: add --version flag and upgrade command

### DIFF
--- a/src/huly_cli/commands/upgrade.py
+++ b/src/huly_cli/commands/upgrade.py
@@ -1,0 +1,121 @@
+"""`huly upgrade` — check PyPI for the latest version and upgrade in-place."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+
+import httpx
+import typer
+
+from huly_cli import __version__
+from huly_cli.output import console, print_error, print_success
+
+PYPI_URL = "https://pypi.org/pypi/huly-cli/json"
+PACKAGE_NAME = "huly-cli"
+
+
+def _parse_version(v: str) -> tuple[int, ...]:
+    """Parse a version string like '0.1.3' into a comparable tuple.
+
+    Non-integer suffixes (e.g. 'rc1', 'dev0') are stripped conservatively so
+    the comparison falls back to the numeric prefix. Unparsable segments are
+    treated as -1 so they sort below any real release.
+    """
+    parts: list[int] = []
+    for segment in v.split("."):
+        digits = ""
+        for ch in segment:
+            if ch.isdigit():
+                digits += ch
+            else:
+                break
+        parts.append(int(digits) if digits else -1)
+    return tuple(parts)
+
+
+def _fetch_latest_version() -> str:
+    """Fetch the latest version of huly-cli from PyPI.
+
+    Raises:
+        httpx.HTTPError: on connection issues, timeouts, non-2xx responses.
+        KeyError / ValueError: on malformed PyPI response.
+    """
+    response = httpx.get(PYPI_URL, timeout=10.0, follow_redirects=True)
+    response.raise_for_status()
+    payload = response.json()
+    return str(payload["info"]["version"])
+
+
+def _detect_installer() -> str:
+    """Detect whether huly-cli was installed via pipx or pip.
+
+    Returns:
+        "pipx" if the current interpreter lives under a pipx venvs directory,
+        "pip" otherwise.
+    """
+    exec_path = (sys.executable or "").replace("\\", "/")
+    if "pipx/venvs" in exec_path or "/pipx/" in exec_path:
+        return "pipx"
+    # Secondary signal: if pipx exists AND the executable lives under the user's
+    # local share (where pipx typically installs), call it pipx.
+    pipx_bin = shutil.which("pipx")
+    if pipx_bin and ("/.local/" in exec_path or "/Application Support/pipx" in exec_path):
+        return "pipx"
+    return "pip"
+
+
+def _build_upgrade_command(installer: str) -> list[str]:
+    if installer == "pipx":
+        pipx_bin = shutil.which("pipx") or "pipx"
+        return [pipx_bin, "upgrade", PACKAGE_NAME]
+    return [sys.executable, "-m", "pip", "install", "--upgrade", PACKAGE_NAME]
+
+
+def upgrade() -> None:
+    """Check PyPI for a newer version and upgrade huly-cli in place."""
+    current = __version__
+    console.print("Checking for updates...")
+
+    try:
+        latest = _fetch_latest_version()
+    except httpx.HTTPError as e:
+        print_error(
+            f"Could not reach PyPI to check for updates: {e}",
+            hint="Check your internet connection and try again.",
+        )
+        raise typer.Exit(1) from e
+    except (KeyError, ValueError) as e:
+        print_error(
+            f"Unexpected response from PyPI: {e}",
+            hint="PyPI may be temporarily misbehaving. Try again shortly.",
+        )
+        raise typer.Exit(1) from e
+
+    if _parse_version(current) >= _parse_version(latest):
+        console.print(f"huly-cli {current} is already up to date.")
+        return
+
+    installer = _detect_installer()
+    cmd = _build_upgrade_command(installer)
+    console.print(
+        f"Upgrading huly-cli [bold]{current}[/bold] → [bold]{latest}[/bold] via {installer}..."
+    )
+
+    try:
+        subprocess.run(cmd, check=True)
+    except subprocess.CalledProcessError as e:
+        print_error(
+            f"Upgrade command failed (exit code {e.returncode}).",
+            hint=f"Tried: {' '.join(cmd)}",
+        )
+        raise typer.Exit(1) from e
+    except FileNotFoundError as e:
+        print_error(
+            f"Could not find the upgrade tool: {e}",
+            hint=f"Install {installer} or run the command manually: {' '.join(cmd)}",
+        )
+        raise typer.Exit(1) from e
+
+    print_success(f"Upgraded huly-cli {current} → {latest}")

--- a/src/huly_cli/main.py
+++ b/src/huly_cli/main.py
@@ -6,6 +6,7 @@ from typing import Annotated
 
 import typer
 
+from huly_cli import __version__
 from huly_cli.commands import (
     auth_cmd,
     components,
@@ -17,6 +18,7 @@ from huly_cli.commands import (
     projects,
     templates,
 )
+from huly_cli.commands import upgrade as upgrade_cmd
 from huly_cli.errors import HulyError, handle_error
 from huly_cli.output import set_json_mode
 
@@ -36,11 +38,29 @@ app.add_typer(documents.app, name="documents")
 app.add_typer(components.app, name="components")
 app.add_typer(milestones.app, name="milestones")
 app.add_typer(templates.app, name="templates")
+app.command("upgrade", help="Upgrade huly-cli to the latest version from PyPI.")(
+    upgrade_cmd.upgrade
+)
+
+
+def _version_callback(value: bool) -> None:
+    if value:
+        print(f"huly-cli {__version__}")
+        raise typer.Exit()
 
 
 @app.callback()
 def global_callback(
     ctx: typer.Context,
+    version: Annotated[
+        bool | None,
+        typer.Option(
+            "--version",
+            callback=_version_callback,
+            is_eager=True,
+            help="Show version and exit.",
+        ),
+    ] = None,
     json_output: Annotated[
         bool,
         typer.Option("--json", help="Output as JSON.", is_eager=False),

--- a/tests/test_version_upgrade.py
+++ b/tests/test_version_upgrade.py
@@ -1,0 +1,163 @@
+"""Regression tests for `huly --version` and `huly upgrade`."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+from typer.testing import CliRunner
+
+from huly_cli import __version__
+from huly_cli.main import app
+
+runner = CliRunner()
+
+
+# ── --version flag ────────────────────────────────────────────────────────────
+
+
+def test_version_flag_prints_package_and_version():
+    """`huly --version` exits 0 and prints 'huly-cli <version>'."""
+    result = runner.invoke(app, ["--version"])
+    assert result.exit_code == 0, result.output
+    assert "huly-cli" in result.output
+    assert __version__ in result.output
+
+
+def test_version_flag_output_format():
+    """`huly --version` output matches exactly 'huly-cli <version>'."""
+    result = runner.invoke(app, ["--version"])
+    assert result.exit_code == 0, result.output
+    assert result.output.strip() == f"huly-cli {__version__}"
+
+
+# ── huly upgrade ──────────────────────────────────────────────────────────────
+
+
+def _make_pypi_response(version: str) -> MagicMock:
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock(return_value=None)
+    resp.json = MagicMock(return_value={"info": {"version": version}})
+    return resp
+
+
+def test_upgrade_already_up_to_date():
+    """When installed version == PyPI version, print a friendly message and exit 0."""
+    fake_get = MagicMock(return_value=_make_pypi_response(__version__))
+    subprocess_mock = MagicMock()
+
+    with (
+        patch("huly_cli.commands.upgrade.httpx.get", fake_get),
+        patch("huly_cli.commands.upgrade.subprocess.run", subprocess_mock),
+    ):
+        result = runner.invoke(app, ["upgrade"])
+
+    assert result.exit_code == 0, result.output
+    assert "already up to date" in result.output.lower()
+    subprocess_mock.assert_not_called()
+    fake_get.assert_called_once()
+
+
+def test_upgrade_runs_pip_when_upgrade_available():
+    """When PyPI has a newer version, run the upgrade subprocess and report success."""
+    higher = "999.999.999"
+    fake_get = MagicMock(return_value=_make_pypi_response(higher))
+    subprocess_run = MagicMock()
+
+    with (
+        patch("huly_cli.commands.upgrade.httpx.get", fake_get),
+        patch("huly_cli.commands.upgrade.subprocess.run", subprocess_run),
+        patch("huly_cli.commands.upgrade._detect_installer", return_value="pip"),
+    ):
+        result = runner.invoke(app, ["upgrade"])
+
+    assert result.exit_code == 0, result.output
+    assert "Upgrading" in result.output
+    assert __version__ in result.output
+    assert higher in result.output
+    subprocess_run.assert_called_once()
+    # The command should target this Python interpreter's pip and huly-cli
+    cmd = subprocess_run.call_args.args[0]
+    assert "pip" in cmd
+    assert "install" in cmd
+    assert "--upgrade" in cmd
+    assert "huly-cli" in cmd
+
+
+def test_upgrade_runs_pipx_when_detected():
+    """When pipx is detected, use `pipx upgrade huly-cli` instead of pip."""
+    higher = "999.999.999"
+    fake_get = MagicMock(return_value=_make_pypi_response(higher))
+    subprocess_run = MagicMock()
+
+    with (
+        patch("huly_cli.commands.upgrade.httpx.get", fake_get),
+        patch("huly_cli.commands.upgrade.subprocess.run", subprocess_run),
+        patch("huly_cli.commands.upgrade._detect_installer", return_value="pipx"),
+        patch("huly_cli.commands.upgrade.shutil.which", return_value="/usr/local/bin/pipx"),
+    ):
+        result = runner.invoke(app, ["upgrade"])
+
+    assert result.exit_code == 0, result.output
+    subprocess_run.assert_called_once()
+    cmd = subprocess_run.call_args.args[0]
+    assert "pipx" in " ".join(cmd)
+    assert "upgrade" in cmd
+    assert "huly-cli" in cmd
+
+
+def test_upgrade_handles_pypi_unreachable():
+    """Network errors reaching PyPI should print a clean error and exit non-zero."""
+    fake_get = MagicMock(side_effect=httpx.ConnectError("network down"))
+    subprocess_run = MagicMock()
+
+    with (
+        patch("huly_cli.commands.upgrade.httpx.get", fake_get),
+        patch("huly_cli.commands.upgrade.subprocess.run", subprocess_run),
+    ):
+        result = runner.invoke(app, ["upgrade"])
+
+    assert result.exit_code != 0
+    combined = (result.output or "") + (result.stderr or "")
+    assert "PyPI" in combined or "reach" in combined.lower()
+    subprocess_run.assert_not_called()
+
+
+def test_upgrade_handles_http_error():
+    """Non-2xx HTTP responses should also fail cleanly without crashing."""
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock(
+        side_effect=httpx.HTTPStatusError(
+            "500", request=MagicMock(), response=MagicMock(status_code=500)
+        )
+    )
+    fake_get = MagicMock(return_value=resp)
+    subprocess_run = MagicMock()
+
+    with (
+        patch("huly_cli.commands.upgrade.httpx.get", fake_get),
+        patch("huly_cli.commands.upgrade.subprocess.run", subprocess_run),
+    ):
+        result = runner.invoke(app, ["upgrade"])
+
+    assert result.exit_code != 0
+    subprocess_run.assert_not_called()
+
+
+def test_upgrade_subprocess_failure_exits_nonzero():
+    """If the upgrade subprocess itself fails, surface a clean non-zero exit."""
+    import subprocess as _sp
+
+    higher = "999.999.999"
+    fake_get = MagicMock(return_value=_make_pypi_response(higher))
+    subprocess_run = MagicMock(side_effect=_sp.CalledProcessError(1, ["pip"]))
+
+    with (
+        patch("huly_cli.commands.upgrade.httpx.get", fake_get),
+        patch("huly_cli.commands.upgrade.subprocess.run", subprocess_run),
+        patch("huly_cli.commands.upgrade._detect_installer", return_value="pip"),
+    ):
+        result = runner.invoke(app, ["upgrade"])
+
+    assert result.exit_code != 0
+    subprocess_run.assert_called_once()


### PR DESCRIPTION
## Summary

Two new user-facing features:

### `huly --version`
Prints the installed version and exits.

```
$ huly --version
huly-cli 0.1.3
```

Wired via a Typer `is_eager=True` callback on the root command, reading `huly_cli.__version__` (not hardcoded).

### `huly upgrade`
Checks PyPI for the latest version, detects whether installed via pipx or pip, and runs the appropriate upgrade command.

```
$ huly upgrade
Checking for updates...
Upgrading huly-cli 0.1.3 → 0.1.4 via pip...
✓ Upgraded huly-cli 0.1.3 → 0.1.4
```

If already up to date:
```
$ huly upgrade
Checking for updates...
huly-cli 0.1.3 is already up to date.
```

## Implementation notes
- No new dependencies — uses `httpx` (already bundled) for the PyPI query and stdlib `subprocess` for the upgrade step.
- pipx detection checks whether `sys.executable` lives under a `pipx/venvs` path segment; falls back to pip otherwise.
- Handles PyPI unreachable, non-2xx responses, and failed upgrade subprocesses with clean non-zero exits and helpful error messages (no tracebacks).

## Tests
New file `tests/test_version_upgrade.py` with 8 tests covering:
- `--version` flag: exit code, output format
- `upgrade` already up-to-date path
- `upgrade` upgrade-available path (pip and pipx)
- `upgrade` PyPI unreachable (connection error)
- `upgrade` PyPI HTTP error
- `upgrade` subprocess failure

All 242 tests pass; ruff lint + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)