### PR TITLE
fix: handle inline ProseMirror descriptions and use updateContent fallback (#30, #31, #32)

### DIFF
--- a/src/huly_cli/client.py
+++ b/src/huly_cli/client.py
@@ -161,7 +161,13 @@ class HulyClient:
         *,
         warn_on_error: bool = True,
     ) -> str | None:
-        """Create entity content via Collaborator RPC and return its blob ref."""
+        """Create entity content via Collaborator RPC and return its blob ref.
+
+        Falls back to ``updateContent`` with an empty source when the
+        ``createContent`` RPC fails (e.g. missing blob-storage bucket).
+        In that case a blob ref is constructed locally using the standard
+        ``{objectId}-{field}-{timestamp}`` format.
+        """
         resp = await self._collaborator_rpc(
             class_id,
             object_id,
@@ -169,15 +175,27 @@ class HulyClient:
             method="createContent",
             payload={"content": {field: markup_json}},
         )
-        if resp is None:
-            if warn_on_error:
-                self._warn_rpc_failure("createContent")
-            return None
-        data = resp.json()
-        blob_ref = data.get("content", {}).get(field)
-        if blob_ref is None:
-            return None
-        return str(blob_ref)
+        if resp is not None:
+            data = resp.json()
+            blob_ref = data.get("content", {}).get(field)
+            if blob_ref is not None:
+                return str(blob_ref)
+
+        # Fallback: updateContent with empty source, construct ref locally
+        resp2 = await self._collaborator_rpc(
+            class_id,
+            object_id,
+            field,
+            method="updateContent",
+            payload={"source": "", "content": {field: markup_json}},
+        )
+        if resp2 is not None:
+            ts = int(time.time() * 1000)
+            return f"{object_id}-{field}-{ts}"
+
+        if warn_on_error:
+            self._warn_rpc_failure("createContent")
+        return None
 
     async def set_content(
         self,

--- a/src/huly_cli/commands/documents.py
+++ b/src/huly_cli/commands/documents.py
@@ -356,13 +356,17 @@ def docs_describe(
                         markup,
                         warn_on_error=False,
                     )
+                    if blob_ref is None:
+                        raise HulyError(
+                            "Failed to create content via Collaborator."
+                        )
                     await client.tx(
                         {
                             "_class": "core:class:TxUpdateDoc",
                             "objectClass": "document:class:Document",
                             "objectSpace": doc.space,
                             "objectId": doc.id,
-                            "operations": {"content": blob_ref or markup},
+                            "operations": {"content": blob_ref},
                             "modifiedBy": auth.account_id,
                             "modifiedOn": int(time.time() * 1000),
                         }

--- a/src/huly_cli/commands/documents.py
+++ b/src/huly_cli/commands/documents.py
@@ -357,9 +357,7 @@ def docs_describe(
                         warn_on_error=False,
                     )
                     if blob_ref is None:
-                        raise HulyError(
-                            "Failed to create content via Collaborator."
-                        )
+                        raise HulyError("Failed to create content via Collaborator.")
                     await client.tx(
                         {
                             "_class": "core:class:TxUpdateDoc",

--- a/src/huly_cli/commands/issues.py
+++ b/src/huly_cli/commands/issues.py
@@ -48,8 +48,11 @@ async def _fetch_person_map(client: HulyClient) -> dict[str, str]:
 def _normalize_issue_doc(raw: dict[str, Any]) -> dict[str, Any]:
     """Coerce live issue documents into the local model's shape."""
     normalized = dict(raw)
-    if normalized.get("description") is None:
+    desc = normalized.get("description")
+    if desc is None:
         normalized["description"] = ""
+    elif isinstance(desc, dict):
+        normalized["description"] = json.dumps(desc)
     return normalized
 
 
@@ -458,13 +461,18 @@ async def _create_impl(
 
             markup = markdown_to_prosemirror(description)
             description_ref = await client.create_description(new_id, markup, warn_on_error=False)
+            if description_ref is None:
+                raise HulyError(
+                    "Failed to create description via Collaborator. "
+                    "The issue was created without a description."
+                )
             await client.tx(
                 {
                     "_class": "core:class:TxUpdateDoc",
                     "objectClass": "tracker:class:Issue",
                     "objectSpace": project_doc.id,
                     "objectId": new_id,
-                    "operations": {"description": description_ref or markup},
+                    "operations": {"description": description_ref},
                 }
             )
         return (
@@ -609,13 +617,17 @@ def issues_describe(
                     blob_ref = await client.create_description(
                         issue.id, markup, warn_on_error=False
                     )
+                    if blob_ref is None:
+                        raise HulyError(
+                            "Failed to create description via Collaborator."
+                        )
                     await client.tx(
                         {
                             "_class": "core:class:TxUpdateDoc",
                             "objectClass": "tracker:class:Issue",
                             "objectSpace": issue.space,
                             "objectId": issue.id,
-                            "operations": {"description": blob_ref or markup},
+                            "operations": {"description": blob_ref},
                         }
                     )
             return issue.identifier or identifier

--- a/src/huly_cli/commands/issues.py
+++ b/src/huly_cli/commands/issues.py
@@ -618,9 +618,7 @@ def issues_describe(
                         issue.id, markup, warn_on_error=False
                     )
                     if blob_ref is None:
-                        raise HulyError(
-                            "Failed to create description via Collaborator."
-                        )
+                        raise HulyError("Failed to create description via Collaborator.")
                     await client.tx(
                         {
                             "_class": "core:class:TxUpdateDoc",

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -193,6 +193,41 @@ async def test_create_description(fake_config, fake_auth):
     assert body["payload"]["content"]["description"] == '{"type":"doc","content":[]}'
 
 
+async def test_create_content_falls_back_to_update_content(fake_config, fake_auth):
+    """Regression for #31/#32: when createContent fails, fall back to updateContent."""
+    doc_id = urllib.parse.quote("uuid-test-456|tracker:class:Issue|issue1|description", safe="")
+    call_count = 0
+
+    def side_effect(request, route):
+        nonlocal call_count
+        call_count += 1
+        body = json.loads(request.content)
+        if body["method"] == "createContent":
+            return respx.MockResponse(500, text='{"error":"The specified bucket does not exist"}')
+        # updateContent fallback succeeds
+        return respx.MockResponse(200, json={})
+
+    with respx.mock:
+        respx.post(f"https://test.example.com/_collaborator/rpc/{doc_id}").mock(
+            side_effect=side_effect
+        )
+        async with HulyClient(fake_config, fake_auth) as client:
+            # Disable retry delay for test speed
+            import huly_cli.client as client_mod
+
+            original_delay = client_mod._RETRY_BASE_DELAY
+            client_mod._RETRY_BASE_DELAY = 0.01
+            try:
+                result = await client.create_description(
+                    "issue1", '{"type":"doc","content":[]}', warn_on_error=False
+                )
+            finally:
+                client_mod._RETRY_BASE_DELAY = original_delay
+
+    assert result is not None
+    assert result.startswith("issue1-description-")
+
+
 async def test_set_description(fake_config, fake_auth):
     doc_id = urllib.parse.quote("uuid-test-456|tracker:class:Issue|issue1|description", safe="")
     with respx.mock:

--- a/tests/test_issue_write_path.py
+++ b/tests/test_issue_write_path.py
@@ -115,10 +115,8 @@ async def test_create_impl_increments_project_sequence_and_uses_blob_ref(fake_co
     create_description_mock.assert_awaited_once()
 
 
-async def test_create_impl_falls_back_to_inline_markup_when_blob_create_fails(
-    fake_config, fake_auth
-):
-    """When create_description returns None, _create_impl writes inline ProseMirror markup."""
+async def test_create_impl_errors_when_blob_create_fails(fake_config, fake_auth):
+    """When create_description returns None, _create_impl raises HulyError."""
     project_doc = {
         "_id": "project-1",
         "name": "My Project",
@@ -137,8 +135,7 @@ async def test_create_impl_falls_back_to_inline_markup_when_blob_create_fails(
             [{"_id": "issue-16", "rank": "0|i0002f:", "space": "project-1"}],
         ]
     )
-    tx_mock = AsyncMock(side_effect=[{"object": {"sequence": 17}}, {}, {}])
-    # create_description returns None → fallback to inline markup
+    tx_mock = AsyncMock(side_effect=[{"object": {"sequence": 17}}, {}])
     create_description_mock = AsyncMock(return_value=None)
 
     with (
@@ -147,24 +144,18 @@ async def test_create_impl_falls_back_to_inline_markup_when_blob_create_fails(
         patch("huly_cli.client.HulyClient.tx", tx_mock),
         patch("huly_cli.client.HulyClient.create_description", create_description_mock),
     ):
-        message = await issues_cmd._create_impl(
-            fake_config,
-            title="Fix auth drift",
-            project="DEMO",
-            status=None,
-            priority="high",
-            assignee=None,
-            description="# Heading",
-        )
-
-    description_tx = tx_mock.await_args_list[2].args[0]
-    description_value = description_tx["operations"]["description"]
-    # Fallback should write inline ProseMirror JSON, not a blob ref
-    assert isinstance(description_value, str)
-    assert description_value.startswith("{")
-    assert "doc" in description_value  # the ProseMirror dict has a "doc" type
-    assert "DEMO-17" in message
-    create_description_mock.assert_awaited_once()
+        import pytest
+        from huly_cli.errors import HulyError
+        with pytest.raises(HulyError, match="Failed to create description"):
+            await issues_cmd._create_impl(
+                fake_config,
+                title="Fix auth drift",
+                project="DEMO",
+                status=None,
+                priority="high",
+                assignee=None,
+                description="# Heading",
+            )
 
 
 async def test_create_impl_skips_description_tx_when_no_description_provided(
@@ -270,8 +261,8 @@ def test_issues_describe_set_creates_blob_ref_when_missing(fake_auth):
     assert tx_mock.await_args.args[0]["operations"] == {"description": "blob-description-2"}
 
 
-def test_issues_describe_set_falls_back_to_inline_markup_when_blob_create_fails(fake_auth):
-    tx_mock = AsyncMock(return_value={})
+def test_issues_describe_set_errors_when_blob_create_fails(fake_auth):
+    """When create_description returns None, describe --set shows an error."""
     create_description_mock = AsyncMock(return_value=None)
 
     with (
@@ -281,15 +272,11 @@ def test_issues_describe_set_falls_back_to_inline_markup_when_blob_create_fails(
             new=AsyncMock(return_value=[_raw_issue(description=None)]),
         ),
         patch("huly_cli.client.HulyClient.create_description", create_description_mock),
-        patch("huly_cli.client.HulyClient.tx", tx_mock),
     ):
         result = runner.invoke(app, ["issues", "describe", "DEMO-1", "--set", "hello world"])
 
-    assert result.exit_code == 0, result.output
-    assert "Description updated for DEMO-1." in result.output
-    description_value = tx_mock.await_args.args[0]["operations"]["description"]
-    assert isinstance(description_value, str)
-    assert description_value.startswith("{")
+    assert result.exit_code == 1, result.output
+    assert "Failed to create description" in result.output
 
 
 def test_documents_describe_set_creates_blob_ref_when_missing(fake_auth):
@@ -331,8 +318,8 @@ def test_documents_describe_set_creates_blob_ref_when_missing(fake_auth):
     assert tx_mock.await_args.args[0]["operations"] == {"content": "blob-content-2"}
 
 
-def test_documents_describe_set_falls_back_to_inline_markup_when_blob_create_fails(fake_auth):
-    tx_mock = AsyncMock(return_value={})
+def test_documents_describe_set_errors_when_blob_create_fails(fake_auth):
+    """When create_content returns None, documents describe --set shows an error."""
     create_content_mock = AsyncMock(return_value=None)
 
     with (
@@ -360,15 +347,49 @@ def test_documents_describe_set_falls_back_to_inline_markup_when_blob_create_fai
             ),
         ),
         patch("huly_cli.client.HulyClient.create_content", create_content_mock),
-        patch("huly_cli.client.HulyClient.tx", tx_mock),
     ):
         result = runner.invoke(app, ["documents", "describe", "doc-1", "--set", "hello world"])
 
-    assert result.exit_code == 0, result.output
-    assert "Content updated for 'My Doc'." in result.output
-    content_value = tx_mock.await_args.args[0]["operations"]["content"]
-    assert isinstance(content_value, str)
-    assert content_value.startswith("{")
+    assert result.exit_code == 1, result.output
+    assert "Failed to create content" in result.output
+
+
+def test_issues_create_errors_when_collaborator_unavailable(fake_auth):
+    """Regression for #31: issues create --description must not silently write inline markup."""
+    project_doc = {
+        "_id": "project-1",
+        "name": "My Project",
+        "identifier": "DEMO",
+        "sequence": 16,
+        "members": [],
+        "owners": [],
+        "description": "",
+        "defaultIssueStatus": "tracker:status:Backlog",
+        "private": False,
+        "archived": False,
+    }
+    find_all_mock = AsyncMock(
+        side_effect=[
+            [project_doc],
+            [{"_id": "issue-16", "rank": "0|i0002f:", "space": "project-1"}],
+        ]
+    )
+    tx_mock = AsyncMock(side_effect=[{"object": {"sequence": 17}}, {}])
+    create_description_mock = AsyncMock(return_value=None)
+
+    with (
+        patch("huly_cli.commands.issues.ensure_auth", new=AsyncMock(return_value=fake_auth)),
+        patch("huly_cli.client.HulyClient.find_all", find_all_mock),
+        patch("huly_cli.client.HulyClient.tx", tx_mock),
+        patch("huly_cli.client.HulyClient.create_description", create_description_mock),
+    ):
+        result = runner.invoke(
+            app,
+            ["issues", "create", "--title", "Test", "--project", "DEMO", "--description", "# Heading"],
+        )
+
+    assert result.exit_code == 1, result.output
+    assert "Failed to create description" in result.output
 
 
 def test_issues_describe_reads_inline_markup_without_collaborator(fake_auth):
@@ -637,6 +658,56 @@ def test_issues_list_status_unknown_in_live_index_raises(fake_auth):
     assert result.exit_code == 1
     assert "Unknown status" in result.output
     assert "no-such-status" in result.output
+
+
+def test_issues_get_handles_dict_description(fake_auth):
+    """Regression for #30: issues get must not crash on inline ProseMirror dict."""
+    raw = _raw_issue(description={"type": "doc", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "hello"}]}]})
+
+    with (
+        patch("huly_cli.commands.issues.ensure_auth", new=AsyncMock(return_value=fake_auth)),
+        patch(
+            "huly_cli.client.HulyClient.find_all",
+            new=AsyncMock(side_effect=[[raw], []]),
+        ),
+    ):
+        result = runner.invoke(app, ["issues", "get", "DEMO-1"])
+
+    assert result.exit_code == 0, result.output
+
+
+def test_issues_describe_reads_dict_description(fake_auth):
+    """Regression for #30: issues describe must handle inline ProseMirror dict."""
+    raw = _raw_issue(description={"type": "doc", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "hello"}]}]})
+
+    with (
+        patch("huly_cli.commands.issues.ensure_auth", new=AsyncMock(return_value=fake_auth)),
+        patch(
+            "huly_cli.client.HulyClient.find_all",
+            new=AsyncMock(return_value=[raw]),
+        ),
+    ):
+        result = runner.invoke(app, ["--json", "issues", "describe", "DEMO-1"])
+
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data["description"] == "hello"
+
+
+def test_issues_list_handles_dict_description(fake_auth):
+    """Regression for #30: issues list must not crash on inline ProseMirror dict."""
+    raw = _raw_issue(description={"type": "doc", "content": []})
+
+    with (
+        patch("huly_cli.commands.issues.ensure_auth", new=AsyncMock(return_value=fake_auth)),
+        patch(
+            "huly_cli.client.HulyClient.find_all",
+            new=AsyncMock(side_effect=[[raw], []]),
+        ),
+    ):
+        result = runner.invoke(app, ["issues", "list"])
+
+    assert result.exit_code == 0, result.output
 
 
 def test_issues_describe_rejects_set_and_set_file(tmp_path):

--- a/tests/test_issue_write_path.py
+++ b/tests/test_issue_write_path.py
@@ -385,7 +385,16 @@ def test_issues_create_errors_when_collaborator_unavailable(fake_auth):
     ):
         result = runner.invoke(
             app,
-            ["issues", "create", "--title", "Test", "--project", "DEMO", "--description", "# Heading"],
+            [
+                "issues",
+                "create",
+                "--title",
+                "Test",
+                "--project",
+                "DEMO",
+                "--description",
+                "# Heading",
+            ],
         )
 
     assert result.exit_code == 1, result.output
@@ -662,7 +671,12 @@ def test_issues_list_status_unknown_in_live_index_raises(fake_auth):
 
 def test_issues_get_handles_dict_description(fake_auth):
     """Regression for #30: issues get must not crash on inline ProseMirror dict."""
-    raw = _raw_issue(description={"type": "doc", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "hello"}]}]})
+    raw = _raw_issue(
+        description={
+            "type": "doc",
+            "content": [{"type": "paragraph", "content": [{"type": "text", "text": "hello"}]}],
+        }
+    )
 
     with (
         patch("huly_cli.commands.issues.ensure_auth", new=AsyncMock(return_value=fake_auth)),
@@ -678,7 +692,12 @@ def test_issues_get_handles_dict_description(fake_auth):
 
 def test_issues_describe_reads_dict_description(fake_auth):
     """Regression for #30: issues describe must handle inline ProseMirror dict."""
-    raw = _raw_issue(description={"type": "doc", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "hello"}]}]})
+    raw = _raw_issue(
+        description={
+            "type": "doc",
+            "content": [{"type": "paragraph", "content": [{"type": "text", "text": "hello"}]}],
+        }
+    )
 
     with (
         patch("huly_cli.commands.issues.ensure_auth", new=AsyncMock(return_value=fake_auth)),

--- a/tests/test_issue_write_path.py
+++ b/tests/test_issue_write_path.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 import json
 from unittest.mock import AsyncMock, patch
 
+import pytest
 from typer.testing import CliRunner
 
 from huly_cli.commands import issues as issues_cmd
+from huly_cli.errors import HulyError
 from huly_cli.issue_utils import IssueStatusIndex
 from huly_cli.main import app
 from huly_cli.models import Issue
@@ -144,8 +146,6 @@ async def test_create_impl_errors_when_blob_create_fails(fake_config, fake_auth)
         patch("huly_cli.client.HulyClient.tx", tx_mock),
         patch("huly_cli.client.HulyClient.create_description", create_description_mock),
     ):
-        import pytest
-        from huly_cli.errors import HulyError
         with pytest.raises(HulyError, match="Failed to create description"):
             await issues_cmd._create_impl(
                 fake_config,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -110,6 +110,14 @@ class TestIssue:
         issue = Issue.model_validate(raw)
         assert issue.modified_by is None
 
+    def test_issue_accepts_dict_description_after_normalization(self):
+        """Regression for #30: API may return inline ProseMirror dict for description."""
+        from huly_cli.commands.issues import _normalize_issue_doc
+        raw = {"_id": "x", "title": "T", "description": {"type": "doc", "content": []}}
+        normalized = _normalize_issue_doc(raw)
+        issue = Issue.model_validate(normalized)
+        assert issue.description.startswith("{")
+
 
 # ── Person ─────────────────────────────────────────────────────────────────────
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -113,6 +113,7 @@ class TestIssue:
     def test_issue_accepts_dict_description_after_normalization(self):
         """Regression for #30: API may return inline ProseMirror dict for description."""
         from huly_cli.commands.issues import _normalize_issue_doc
+
         raw = {"_id": "x", "title": "T", "description": {"type": "doc", "content": []}}
         normalized = _normalize_issue_doc(raw)
         issue = Issue.model_validate(normalized)


### PR DESCRIPTION
## Summary

- **Issue #30**: `issues get`/`describe`/`list` crashed when the API returned an inline ProseMirror dict instead of a string blob ref. `_normalize_issue_doc()` now converts dict descriptions to JSON strings before Pydantic validation.

- **Issues #31 & #32**: Descriptions and document content written by the CLI were stored as raw ProseMirror JSON in `description_ref`/`content_ref`, which the web UI can't render (shows blank). `create_content()` now falls back to `updateContent` with an empty source when `createContent` RPC fails (e.g. missing blob-storage bucket), constructing a blob ref locally in the standard `{objectId}-{field}-{timestamp}` format. If both methods fail, a `HulyError` is raised instead of silently writing inline markup.

## Test plan

- [x] 248 unit tests pass
- [x] Live smoke test passes (read-only + write checks against ROA workspace)
- [x] Manually verified: issue description and document content created via CLI render correctly in Huly web UI
- [x] Regression tests added for dict description normalization (4 tests)
- [x] Regression test added for `updateContent` fallback in client (1 test)
- [x] Existing fallback tests updated to assert error behavior when both RPC methods fail (3 tests)
- [x] Command-level test for `issues create --description` Collaborator failure (1 test)

Closes #30, closes #31, closes #32