### PR TITLE
feat: add labels CRUD, due date, and component/label linking on issues

### DIFF
--- a/src/huly_cli/commands/issues.py
+++ b/src/huly_cli/commands/issues.py
@@ -10,6 +10,7 @@ from typing import Annotated, Any
 import typer
 
 from huly_cli.auth import ensure_auth
+from huly_cli.commands.milestones import _parse_date_ms
 from huly_cli.client import HulyClient
 from huly_cli.config import load_config
 from huly_cli.errors import AuthError, HulyError, NotFoundError
@@ -119,6 +120,49 @@ def _resolve_priority_value(priority: str) -> int:
             valid = ", ".join(PRIORITY_FROM_NAME.keys())
             raise HulyError(f"Unknown priority '{priority}'. Valid values: {valid}") from None
         return priority_int
+
+
+async def _resolve_component(client: HulyClient, name_or_id: str, project_id: str | None = None) -> str:
+    """Resolve a component name (fuzzy) or ID to its internal ID."""
+    query: dict[str, Any] = {}
+    if project_id:
+        query["space"] = project_id
+    raw = await client.find_all("tracker:class:Component", query=query, options={"limit": 500})
+    for doc in raw:
+        if doc.get("_id") == name_or_id:
+            return doc["_id"]
+    needle = name_or_id.lower()
+    for doc in raw:
+        if needle in (doc.get("label") or "").lower():
+            return doc["_id"]
+    raise NotFoundError(f"Component '{name_or_id}' not found.")
+
+
+async def _resolve_label_tag(client: HulyClient, title: str) -> str | None:
+    """Find the tag value for a label by title."""
+    raw = await client.find_all("tags:class:TagReference", options={"limit": 1000})
+    needle = title.lower()
+    for doc in raw:
+        if (doc.get("title") or "").lower() == needle:
+            return doc.get("tag")
+    return None
+
+
+async def _attach_label(client: HulyClient, issue_id: str, space: str, title: str, tag: str | None = None) -> str:
+    """Create a TagReference document attaching a label to an issue."""
+    new_id = secrets.token_hex(12)
+    await client.tx({
+        "_class": "core:class:TxCreateDoc",
+        "objectClass": "tags:class:TagReference",
+        "objectSpace": space,
+        "objectId": new_id,
+        "attributes": {
+            "tag": tag or "",
+            "title": title,
+            "attachedTo": issue_id,
+        },
+    })
+    return new_id
 
 
 async def _resolve_issue_status_id(
@@ -378,6 +422,9 @@ def issues_create(
     description: Annotated[
         str | None, typer.Option("--description", help="Markdown description text.")
     ] = None,
+    due_date: Annotated[str | None, typer.Option("--due-date", help="Due date (YYYY-MM-DD).")] = None,
+    component: Annotated[str | None, typer.Option("--component", help="Component name or ID.")] = None,
+    label: Annotated[list[str] | None, typer.Option("--label", help="Label to attach (repeatable).")] = None,
 ) -> None:
     """Create a new issue."""
     overrides: dict = ctx.obj or {}
@@ -387,7 +434,7 @@ def issues_create(
     )
     try:
         result = asyncio.run(
-            _create_impl(config, title, project, status, priority, assignee, description)
+            _create_impl(config, title, project, status, priority, assignee, description, due_date, component, label)
         )
         print_success(result)
     except NotFoundError as e:
@@ -406,6 +453,9 @@ async def _create_impl(
     priority: str,
     assignee: str | None,
     description: str | None,
+    due_date: str | None = None,
+    component: str | None = None,
+    labels: list[str] | None = None,
 ) -> str:
     auth = await ensure_auth(config)
     async with HulyClient(config, auth) as client:
@@ -417,6 +467,16 @@ async def _create_impl(
         )
         priority_int = _resolve_priority_value(priority)
         person_id = await _resolve_person_by_name(client, assignee) if assignee else None
+
+        due_date_ms: int | None = None
+        if due_date:
+            try:
+                due_date_ms = _parse_date_ms(due_date)
+            except ValueError:
+                raise HulyError(f"Invalid date format '{due_date}'. Use YYYY-MM-DD.") from None
+
+        component_id = await _resolve_component(client, component, project_doc.id) if component else None
+
         new_id = secrets.token_hex(12)
         number, identifier_value, rank = await _next_issue_number_and_rank(client, project_doc)
 
@@ -432,7 +492,7 @@ async def _create_impl(
                 "priority": priority_int,
                 "assignee": person_id,
                 "kind": "tracker:taskTypes:Issue",
-                "component": None,
+                "component": component_id,
                 "milestone": None,
                 "number": number,
                 "estimation": 0,
@@ -444,7 +504,7 @@ async def _create_impl(
                 "attachedTo": "tracker:ids:NoParent",
                 "parents": [],
                 "childInfo": [],
-                "dueDate": None,
+                "dueDate": due_date_ms,
                 "rank": rank,
                 "comments": 0,
                 "subIssues": 0,
@@ -467,6 +527,11 @@ async def _create_impl(
                     "operations": {"description": description_ref or markup},
                 }
             )
+        if labels:
+            for label_name in labels:
+                tag_ref = await _resolve_label_tag(client, label_name)
+                await _attach_label(client, new_id, project_doc.id, label_name, tag_ref)
+
         return (
             f"Issue {identifier_value} created in project {project_doc.identifier} (id: {new_id})"
         )
@@ -487,6 +552,9 @@ def issues_update(
             "--assignee", help='New assignee person name (fuzzy match). Use "" to unassign.'
         ),
     ] = None,
+    due_date: Annotated[str | None, typer.Option("--due-date", help='Due date (YYYY-MM-DD). Use "" to clear.')] = None,
+    component: Annotated[str | None, typer.Option("--component", help='Component name or ID. Use "" to unset.')] = None,
+    label: Annotated[list[str] | None, typer.Option("--label", help="Label to attach (repeatable).")] = None,
 ) -> None:
     """Update an existing issue."""
     overrides: dict = ctx.obj or {}
@@ -495,7 +563,7 @@ def issues_update(
         workspace_override=overrides.get("workspace"),
     )
     try:
-        asyncio.run(_update_impl(config, identifier, title, status, priority, assignee))
+        asyncio.run(_update_impl(config, identifier, title, status, priority, assignee, due_date, component, label))
         print_success(f"Issue {identifier} updated.")
     except NotFoundError as e:
         print_error(e.message)
@@ -512,6 +580,9 @@ async def _update_impl(
     status: str | None,
     priority: str | None,
     assignee: str | None,
+    due_date: str | None = None,
+    component: str | None = None,
+    labels: list[str] | None = None,
 ) -> None:
     auth = await ensure_auth(config)
     async with HulyClient(config, auth) as client:
@@ -534,21 +605,42 @@ async def _update_impl(
             else:
                 operations["assignee"] = await _resolve_person_by_name(client, assignee)
 
-        if not operations:
+        if due_date is not None:
+            if due_date == "":
+                operations["dueDate"] = None
+            else:
+                try:
+                    operations["dueDate"] = _parse_date_ms(due_date)
+                except ValueError:
+                    raise HulyError(f"Invalid date format '{due_date}'. Use YYYY-MM-DD.") from None
+
+        if component is not None:
+            if component == "":
+                operations["component"] = None
+            else:
+                operations["component"] = await _resolve_component(client, component)
+
+        if labels:
+            for label_name in labels:
+                tag_ref = await _resolve_label_tag(client, label_name)
+                await _attach_label(client, issue.id, issue.space, label_name, tag_ref)
+
+        if not operations and not labels:
             print_warning(
-                "No fields to update — provide at least one of --title, --status, --priority, --assignee."
+                "No fields to update — provide at least one of --title, --status, --priority, --assignee, --due-date, --component, --label."
             )
             return
 
-        transaction = {
-            "_class": "core:class:TxUpdateDoc",
-            "objectClass": "tracker:class:Issue",
-            "objectSpace": issue.space,
-            "objectId": issue.id,
-            "operations": operations,
-        }
+        if operations:
+            transaction = {
+                "_class": "core:class:TxUpdateDoc",
+                "objectClass": "tracker:class:Issue",
+                "objectSpace": issue.space,
+                "objectId": issue.id,
+                "operations": operations,
+            }
 
-        await client.tx(transaction)
+            await client.tx(transaction)
 
 
 @app.command("describe")

--- a/src/huly_cli/commands/issues.py
+++ b/src/huly_cli/commands/issues.py
@@ -122,7 +122,9 @@ def _resolve_priority_value(priority: str) -> int:
         return priority_int
 
 
-async def _resolve_component(client: HulyClient, name_or_id: str, project_id: str | None = None) -> str:
+async def _resolve_component(
+    client: HulyClient, name_or_id: str, project_id: str | None = None
+) -> str:
     """Resolve a component name (fuzzy) or ID to its internal ID."""
     query: dict[str, Any] = {}
     if project_id:
@@ -148,20 +150,24 @@ async def _resolve_label_tag(client: HulyClient, title: str) -> str | None:
     return None
 
 
-async def _attach_label(client: HulyClient, issue_id: str, space: str, title: str, tag: str | None = None) -> str:
+async def _attach_label(
+    client: HulyClient, issue_id: str, space: str, title: str, tag: str | None = None
+) -> str:
     """Create a TagReference document attaching a label to an issue."""
     new_id = secrets.token_hex(12)
-    await client.tx({
-        "_class": "core:class:TxCreateDoc",
-        "objectClass": "tags:class:TagReference",
-        "objectSpace": space,
-        "objectId": new_id,
-        "attributes": {
-            "tag": tag or "",
-            "title": title,
-            "attachedTo": issue_id,
-        },
-    })
+    await client.tx(
+        {
+            "_class": "core:class:TxCreateDoc",
+            "objectClass": "tags:class:TagReference",
+            "objectSpace": space,
+            "objectId": new_id,
+            "attributes": {
+                "tag": tag or "",
+                "title": title,
+                "attachedTo": issue_id,
+            },
+        }
+    )
     return new_id
 
 
@@ -422,9 +428,15 @@ def issues_create(
     description: Annotated[
         str | None, typer.Option("--description", help="Markdown description text.")
     ] = None,
-    due_date: Annotated[str | None, typer.Option("--due-date", help="Due date (YYYY-MM-DD).")] = None,
-    component: Annotated[str | None, typer.Option("--component", help="Component name or ID.")] = None,
-    label: Annotated[list[str] | None, typer.Option("--label", help="Label to attach (repeatable).")] = None,
+    due_date: Annotated[
+        str | None, typer.Option("--due-date", help="Due date (YYYY-MM-DD).")
+    ] = None,
+    component: Annotated[
+        str | None, typer.Option("--component", help="Component name or ID.")
+    ] = None,
+    label: Annotated[
+        list[str] | None, typer.Option("--label", help="Label to attach (repeatable).")
+    ] = None,
 ) -> None:
     """Create a new issue."""
     overrides: dict = ctx.obj or {}
@@ -434,7 +446,18 @@ def issues_create(
     )
     try:
         result = asyncio.run(
-            _create_impl(config, title, project, status, priority, assignee, description, due_date, component, label)
+            _create_impl(
+                config,
+                title,
+                project,
+                status,
+                priority,
+                assignee,
+                description,
+                due_date,
+                component,
+                label,
+            )
         )
         print_success(result)
     except NotFoundError as e:
@@ -475,7 +498,9 @@ async def _create_impl(
             except ValueError:
                 raise HulyError(f"Invalid date format '{due_date}'. Use YYYY-MM-DD.") from None
 
-        component_id = await _resolve_component(client, component, project_doc.id) if component else None
+        component_id = (
+            await _resolve_component(client, component, project_doc.id) if component else None
+        )
 
         new_id = secrets.token_hex(12)
         number, identifier_value, rank = await _next_issue_number_and_rank(client, project_doc)
@@ -552,9 +577,15 @@ def issues_update(
             "--assignee", help='New assignee person name (fuzzy match). Use "" to unassign.'
         ),
     ] = None,
-    due_date: Annotated[str | None, typer.Option("--due-date", help='Due date (YYYY-MM-DD). Use "" to clear.')] = None,
-    component: Annotated[str | None, typer.Option("--component", help='Component name or ID. Use "" to unset.')] = None,
-    label: Annotated[list[str] | None, typer.Option("--label", help="Label to attach (repeatable).")] = None,
+    due_date: Annotated[
+        str | None, typer.Option("--due-date", help='Due date (YYYY-MM-DD). Use "" to clear.')
+    ] = None,
+    component: Annotated[
+        str | None, typer.Option("--component", help='Component name or ID. Use "" to unset.')
+    ] = None,
+    label: Annotated[
+        list[str] | None, typer.Option("--label", help="Label to attach (repeatable).")
+    ] = None,
 ) -> None:
     """Update an existing issue."""
     overrides: dict = ctx.obj or {}
@@ -563,7 +594,11 @@ def issues_update(
         workspace_override=overrides.get("workspace"),
     )
     try:
-        asyncio.run(_update_impl(config, identifier, title, status, priority, assignee, due_date, component, label))
+        asyncio.run(
+            _update_impl(
+                config, identifier, title, status, priority, assignee, due_date, component, label
+            )
+        )
         print_success(f"Issue {identifier} updated.")
     except NotFoundError as e:
         print_error(e.message)

--- a/src/huly_cli/commands/issues.py
+++ b/src/huly_cli/commands/issues.py
@@ -10,8 +10,8 @@ from typing import Annotated, Any
 import typer
 
 from huly_cli.auth import ensure_auth
-from huly_cli.commands.milestones import _parse_date_ms
 from huly_cli.client import HulyClient
+from huly_cli.commands.milestones import _parse_date_ms
 from huly_cli.config import load_config
 from huly_cli.errors import AuthError, HulyError, NotFoundError
 from huly_cli.issue_utils import (

--- a/src/huly_cli/commands/labels.py
+++ b/src/huly_cli/commands/labels.py
@@ -1,20 +1,42 @@
-"""Labels commands: list."""
+"""Labels commands: list, get, create, update, delete."""
 
 from __future__ import annotations
 
 import asyncio
+import secrets
+import time
 from collections import Counter
-from typing import Any
+from typing import Annotated, Any
 
 import typer
 
+from huly_cli.auth import ensure_auth
 from huly_cli.client import HulyClient
 from huly_cli.config import load_config
-from huly_cli.errors import AuthError, HulyError
+from huly_cli.errors import AuthError, HulyError, NotFoundError
 from huly_cli.models import TagReference
-from huly_cli.output import print_error, print_list
+from huly_cli.output import print_error, print_item, print_list, print_success, print_warning
 
 app = typer.Typer(help="Manage issue labels.", no_args_is_help=True)
+
+
+# ── Shared helpers ────────────────────────────────────────────────────────────
+
+
+async def _resolve_project_by_identifier(client: HulyClient, identifier: str) -> tuple[str, str]:
+    """Return (project_id, project_name) for the given identifier."""
+    projects = await client.find_all(
+        "tracker:class:Project",
+        query={"identifier": identifier.upper()},
+        options={"limit": 1},
+    )
+    if not projects:
+        raise NotFoundError(f"Project '{identifier}' not found.")
+    proj = projects[0]
+    return proj["_id"], proj.get("name", identifier)
+
+
+# ── Commands ──────────────────────────────────────────────────────────────────
 
 
 @app.command("list")
@@ -27,8 +49,6 @@ def labels_list(ctx: typer.Context) -> None:
     )
 
     async def _run() -> list[dict[str, Any]]:
-        from huly_cli.auth import ensure_auth
-
         auth = await ensure_auth(config)
         async with HulyClient(config, auth) as client:
             raw = await client.find_all("tags:class:TagReference", options={"limit": 1000})
@@ -63,3 +83,222 @@ def labels_list(ctx: typer.Context) -> None:
         raise typer.Exit(1) from e
 
     print_list(rows, columns=["title", "count"], title="Labels")
+
+
+@app.command("get")
+def labels_get(
+    ctx: typer.Context,
+    label_id: str = typer.Argument(..., help="Label internal ID."),
+) -> None:
+    """Get details of a label."""
+    overrides: dict = ctx.obj or {}
+    config = load_config(
+        url_override=overrides.get("url"),
+        workspace_override=overrides.get("workspace"),
+    )
+
+    async def _run() -> dict[str, Any]:
+        auth = await ensure_auth(config)
+        async with HulyClient(config, auth) as client:
+            raw = await client.find_all(
+                "tags:class:TagReference",
+                query={"_id": label_id},
+                options={"limit": 1},
+            )
+            if not raw:
+                raise NotFoundError(f"Label '{label_id}' not found.")
+            tag = TagReference.model_validate(raw[0])
+        return {
+            "title": tag.title or "",
+            "id": tag.id,
+            "tag": tag.tag or "",
+            "color": tag.color,
+            "attached_to": tag.attached_to,
+            "space": tag.space,
+            "created_by": tag.created_by,
+            "modified_by": tag.modified_by,
+        }
+
+    try:
+        data = asyncio.run(_run())
+    except NotFoundError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+    except AuthError as e:
+        print_error(e.message, hint="Run 'huly auth login' to authenticate.")
+        raise typer.Exit(2) from e
+    except HulyError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+
+    print_item(data, title=f"Label: {data.get('title', label_id)}")
+
+
+@app.command("create")
+def labels_create(
+    ctx: typer.Context,
+    title: Annotated[str, typer.Option("--title", help="Label title.")] = ...,
+    project: Annotated[
+        str, typer.Option("--project", help='Project identifier (e.g. "DEMO").')
+    ] = ...,
+    color: Annotated[
+        int | None, typer.Option("--color", help="Label color (integer).")
+    ] = None,
+) -> None:
+    """Create a new label."""
+    overrides: dict = ctx.obj or {}
+    config = load_config(
+        url_override=overrides.get("url"),
+        workspace_override=overrides.get("workspace"),
+    )
+
+    async def _run() -> str:
+        auth = await ensure_auth(config)
+        async with HulyClient(config, auth) as client:
+            project_id, _ = await _resolve_project_by_identifier(client, project)
+
+            new_id = secrets.token_hex(12)
+
+            transaction = {
+                "_class": "core:class:TxCreateDoc",
+                "objectClass": "tags:class:TagReference",
+                "objectSpace": project_id,
+                "objectId": new_id,
+                "attributes": {
+                    "tag": "",
+                    "title": title,
+                    "color": color,
+                    "attachedTo": "",
+                },
+                "modifiedBy": auth.account_id,
+                "modifiedOn": int(time.time() * 1000),
+            }
+
+            await client.tx(transaction)
+        return new_id
+
+    try:
+        new_id = asyncio.run(_run())
+        print_success(f"Label created in project '{project}' (id: {new_id})")
+    except NotFoundError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+    except AuthError as e:
+        print_error(e.message, hint="Run 'huly auth login' to authenticate.")
+        raise typer.Exit(2) from e
+    except HulyError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+
+
+@app.command("update")
+def labels_update(
+    ctx: typer.Context,
+    label_id: str = typer.Argument(..., help="Label internal ID."),
+    title: Annotated[str | None, typer.Option("--title", help="New label title.")] = None,
+    color: Annotated[int | None, typer.Option("--color", help="New label color (integer).")] = None,
+) -> None:
+    """Update an existing label."""
+    overrides: dict = ctx.obj or {}
+    config = load_config(
+        url_override=overrides.get("url"),
+        workspace_override=overrides.get("workspace"),
+    )
+
+    async def _run() -> None:
+        auth = await ensure_auth(config)
+        async with HulyClient(config, auth) as client:
+            raw = await client.find_all(
+                "tags:class:TagReference",
+                query={"_id": label_id},
+                options={"limit": 1},
+            )
+            if not raw:
+                raise NotFoundError(f"Label '{label_id}' not found.")
+            tag = TagReference.model_validate(raw[0])
+
+            operations: dict = {}
+
+            if title is not None:
+                operations["title"] = title
+
+            if color is not None:
+                operations["color"] = color
+
+            if not operations:
+                print_warning(
+                    "No fields to update — provide at least one of --title, --color."
+                )
+                return
+
+            transaction = {
+                "_class": "core:class:TxUpdateDoc",
+                "objectClass": "tags:class:TagReference",
+                "objectSpace": tag.space,
+                "objectId": tag.id,
+                "operations": operations,
+                "modifiedBy": auth.account_id,
+                "modifiedOn": int(time.time() * 1000),
+            }
+
+            await client.tx(transaction)
+
+    try:
+        asyncio.run(_run())
+        print_success(f"Label {label_id} updated.")
+    except NotFoundError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+    except AuthError as e:
+        print_error(e.message, hint="Run 'huly auth login' to authenticate.")
+        raise typer.Exit(2) from e
+    except HulyError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+
+
+@app.command("delete")
+def labels_delete(
+    ctx: typer.Context,
+    label_id: str = typer.Argument(..., help="Label internal ID."),
+) -> None:
+    """Delete an existing label."""
+    overrides: dict = ctx.obj or {}
+    config = load_config(
+        url_override=overrides.get("url"),
+        workspace_override=overrides.get("workspace"),
+    )
+
+    async def _run() -> None:
+        auth = await ensure_auth(config)
+        async with HulyClient(config, auth) as client:
+            raw = await client.find_all(
+                "tags:class:TagReference",
+                query={"_id": label_id},
+                options={"limit": 1},
+            )
+            if not raw:
+                raise NotFoundError(f"Label '{label_id}' not found.")
+            tag = TagReference.model_validate(raw[0])
+
+            await client.tx(
+                {
+                    "_class": "core:class:TxRemoveDoc",
+                    "objectClass": "tags:class:TagReference",
+                    "objectSpace": tag.space,
+                    "objectId": tag.id,
+                }
+            )
+
+    try:
+        asyncio.run(_run())
+        print_success(f"Label {label_id} deleted.")
+    except NotFoundError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+    except AuthError as e:
+        print_error(e.message, hint="Run 'huly auth login' to authenticate.")
+        raise typer.Exit(2) from e
+    except HulyError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e

--- a/src/huly_cli/commands/labels.py
+++ b/src/huly_cli/commands/labels.py
@@ -141,9 +141,7 @@ def labels_create(
     project: Annotated[
         str, typer.Option("--project", help='Project identifier (e.g. "DEMO").')
     ] = ...,
-    color: Annotated[
-        int | None, typer.Option("--color", help="Label color (integer).")
-    ] = None,
+    color: Annotated[int | None, typer.Option("--color", help="Label color (integer).")] = None,
 ) -> None:
     """Create a new label."""
     overrides: dict = ctx.obj or {}
@@ -226,9 +224,7 @@ def labels_update(
                 operations["color"] = color
 
             if not operations:
-                print_warning(
-                    "No fields to update — provide at least one of --title, --color."
-                )
+                print_warning("No fields to update — provide at least one of --title, --color.")
                 return
 
             transaction = {

--- a/src/huly_cli/models.py
+++ b/src/huly_cli/models.py
@@ -114,9 +114,16 @@ class PersonAccount(BaseModel):
 class TagReference(BaseModel):
     model_config = {"populate_by_name": True}
 
+    id: str = Field(alias="_id")
     tag: str | None = None
     title: str | None = None
+    color: int | None = None
     attached_to: str = Field("", alias="attachedTo")
+    space: str = ""
+    created_by: str = Field("", alias="createdBy")
+    created_on: int = Field(0, alias="createdOn")
+    modified_by: str = Field("", alias="modifiedBy")
+    modified_on: int = Field(0, alias="modifiedOn")
 
 
 # ── Document / Teamspace ──────────────────────────────────────────────────────

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -363,9 +363,7 @@ def test_labels_create_writes_create_doc_tx():
         patch("huly_cli.client.HulyClient.find_all", find_mock),
         patch("huly_cli.client.HulyClient.tx", tx_mock),
     ):
-        result = runner.invoke(
-            app, ["labels", "create", "--title", "Bug", "--project", "TP"]
-        )
+        result = runner.invoke(app, ["labels", "create", "--title", "Bug", "--project", "TP"])
 
     assert result.exit_code == 0, result.output
     create_tx = tx_mock.await_args.args[0]
@@ -382,9 +380,7 @@ def test_labels_create_project_not_found_exits_nonzero():
         patch("huly_cli.client.HulyClient.find_all", find_mock),
         patch("huly_cli.client.HulyClient.tx", tx_mock),
     ):
-        result = runner.invoke(
-            app, ["labels", "create", "--title", "Bug", "--project", "MISSING"]
-        )
+        result = runner.invoke(app, ["labels", "create", "--title", "Bug", "--project", "MISSING"])
 
     assert result.exit_code == 1
     tx_mock.assert_not_awaited()
@@ -398,9 +394,7 @@ def test_labels_update_writes_update_doc_tx():
         patch("huly_cli.client.HulyClient.find_all", new=AsyncMock(return_value=TAG_DETAIL_DATA)),
         patch("huly_cli.client.HulyClient.tx", tx_mock),
     ):
-        result = runner.invoke(
-            app, ["labels", "update", "t1", "--title", "Feature"]
-        )
+        result = runner.invoke(app, ["labels", "update", "t1", "--title", "Feature"])
 
     assert result.exit_code == 0, result.output
     update_tx = tx_mock.await_args.args[0]
@@ -432,9 +426,7 @@ def test_labels_update_not_found_exits_nonzero():
         patch("huly_cli.client.HulyClient.find_all", find_mock),
         patch("huly_cli.client.HulyClient.tx", tx_mock),
     ):
-        result = runner.invoke(
-            app, ["labels", "update", "missing-id", "--title", "X"]
-        )
+        result = runner.invoke(app, ["labels", "update", "missing-id", "--title", "X"])
 
     assert result.exit_code == 1
     tx_mock.assert_not_awaited()
@@ -492,10 +484,12 @@ def _issue_create_find_side_effects(*, extra_finds=None):
 
 def test_issues_create_with_due_date():
     find_mock = AsyncMock(side_effect=_issue_create_find_side_effects())
-    tx_mock = AsyncMock(side_effect=[
-        {"object": {"sequence": 5}},  # sequence increment
-        {},  # issue create
-    ])
+    tx_mock = AsyncMock(
+        side_effect=[
+            {"object": {"sequence": 5}},  # sequence increment
+            {},  # issue create
+        ]
+    )
 
     with (
         _auth_patch(),
@@ -515,13 +509,13 @@ def test_issues_create_with_due_date():
 
 def test_issues_create_with_component():
     component_find = [{"_id": "comp1", "label": "Auth Service", "space": "proj1"}]
-    find_mock = AsyncMock(
-        side_effect=_issue_create_find_side_effects(extra_finds=[component_find])
+    find_mock = AsyncMock(side_effect=_issue_create_find_side_effects(extra_finds=[component_find]))
+    tx_mock = AsyncMock(
+        side_effect=[
+            {"object": {"sequence": 5}},
+            {},
+        ]
     )
-    tx_mock = AsyncMock(side_effect=[
-        {"object": {"sequence": 5}},
-        {},
-    ])
 
     with (
         _auth_patch(),
@@ -530,7 +524,16 @@ def test_issues_create_with_component():
     ):
         result = runner.invoke(
             app,
-            ["issues", "create", "--title", "Test", "--project", "TP", "--component", "Auth Service"],
+            [
+                "issues",
+                "create",
+                "--title",
+                "Test",
+                "--project",
+                "TP",
+                "--component",
+                "Auth Service",
+            ],
         )
 
     assert result.exit_code == 0, result.output
@@ -548,11 +551,13 @@ def test_issues_create_with_label():
             label_find,  # _resolve_label_tag
         ]
     )
-    tx_mock = AsyncMock(side_effect=[
-        {"object": {"sequence": 5}},  # sequence increment
-        {},  # issue create
-        {},  # tag attach
-    ])
+    tx_mock = AsyncMock(
+        side_effect=[
+            {"object": {"sequence": 5}},  # sequence increment
+            {},  # issue create
+            {},  # tag attach
+        ]
+    )
 
     with (
         _auth_patch(),
@@ -584,9 +589,7 @@ def test_issues_update_with_due_date():
         patch("huly_cli.client.HulyClient.find_all", find_mock),
         patch("huly_cli.client.HulyClient.tx", tx_mock),
     ):
-        result = runner.invoke(
-            app, ["issues", "update", "TP-1", "--due-date", "2024-06-15"]
-        )
+        result = runner.invoke(app, ["issues", "update", "TP-1", "--due-date", "2024-06-15"])
 
     assert result.exit_code == 0, result.output
     update_tx = tx_mock.await_args.args[0]
@@ -602,9 +605,7 @@ def test_issues_update_clear_due_date():
         patch("huly_cli.client.HulyClient.find_all", find_mock),
         patch("huly_cli.client.HulyClient.tx", tx_mock),
     ):
-        result = runner.invoke(
-            app, ["issues", "update", "TP-1", "--due-date", ""]
-        )
+        result = runner.invoke(app, ["issues", "update", "TP-1", "--due-date", ""])
 
     assert result.exit_code == 0, result.output
     update_tx = tx_mock.await_args.args[0]
@@ -621,9 +622,7 @@ def test_issues_update_with_component():
         patch("huly_cli.client.HulyClient.find_all", find_mock),
         patch("huly_cli.client.HulyClient.tx", tx_mock),
     ):
-        result = runner.invoke(
-            app, ["issues", "update", "TP-1", "--component", "Auth Service"]
-        )
+        result = runner.invoke(app, ["issues", "update", "TP-1", "--component", "Auth Service"])
 
     assert result.exit_code == 0, result.output
     update_tx = tx_mock.await_args.args[0]
@@ -639,9 +638,7 @@ def test_issues_update_clear_component():
         patch("huly_cli.client.HulyClient.find_all", find_mock),
         patch("huly_cli.client.HulyClient.tx", tx_mock),
     ):
-        result = runner.invoke(
-            app, ["issues", "update", "TP-1", "--component", ""]
-        )
+        result = runner.invoke(app, ["issues", "update", "TP-1", "--component", ""])
 
     assert result.exit_code == 0, result.output
     update_tx = tx_mock.await_args.args[0]
@@ -651,19 +648,19 @@ def test_issues_update_clear_component():
 def test_issues_update_with_label():
     label_find = [{"_id": "tr1", "tag": "tag-bug", "title": "Bug", "attachedTo": "other"}]
     find_mock = AsyncMock(side_effect=[ISSUE_DATA, label_find])
-    tx_mock = AsyncMock(side_effect=[
-        {},  # tag attach
-        {},  # (no update tx since only labels, no operations)
-    ])
+    tx_mock = AsyncMock(
+        side_effect=[
+            {},  # tag attach
+            {},  # (no update tx since only labels, no operations)
+        ]
+    )
 
     with (
         _auth_patch(),
         patch("huly_cli.client.HulyClient.find_all", find_mock),
         patch("huly_cli.client.HulyClient.tx", tx_mock),
     ):
-        result = runner.invoke(
-            app, ["issues", "update", "TP-1", "--label", "Bug"]
-        )
+        result = runner.invoke(app, ["issues", "update", "TP-1", "--label", "Bug"])
 
     assert result.exit_code == 0, result.output
     # First tx call is the tag attachment

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -33,6 +33,7 @@ def _auth_patch():
         "huly_cli.commands.issues",
         "huly_cli.commands.documents",
         "huly_cli.commands.components",
+        "huly_cli.commands.labels",
     ]
     with ExitStack() as stack:
         for module in modules:
@@ -303,6 +304,374 @@ def test_labels_list_handles_null_title():
         result = runner.invoke(app, ["labels", "list"])
     assert result.exit_code == 0, result.output
     assert "Real Label" in result.output
+
+
+# ── labels CRUD ───────────────────────────────────────────────────────────────
+
+TAG_DETAIL_DATA = [
+    {
+        "_id": "t1",
+        "tag": "tag1",
+        "title": "Bug",
+        "color": 1,
+        "attachedTo": "i1",
+        "space": "p1",
+        "createdBy": "",
+        "createdOn": 0,
+        "modifiedBy": "",
+        "modifiedOn": 0,
+    }
+]
+
+PROJECT_DATA = [
+    {
+        "_id": "proj1",
+        "name": "Test",
+        "identifier": "TP",
+        "members": [],
+        "owners": [],
+        "sequence": 5,
+        "description": "",
+        "defaultIssueStatus": "tracker:status:Backlog",
+        "private": False,
+        "archived": False,
+    }
+]
+
+
+def test_labels_get_returns_detail():
+    find_mock = AsyncMock(return_value=TAG_DETAIL_DATA)
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["labels", "get", "t1"])
+    assert result.exit_code == 0, result.output
+    assert "Bug" in result.output
+
+
+def test_labels_get_not_found_exits_nonzero():
+    find_mock = AsyncMock(return_value=[])
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["labels", "get", "t1"])
+    assert result.exit_code == 1
+
+
+def test_labels_create_writes_create_doc_tx():
+    tx_mock = AsyncMock(return_value={})
+    find_mock = AsyncMock(return_value=PROJECT_DATA)
+
+    with (
+        _auth_patch(),
+        patch("huly_cli.client.HulyClient.find_all", find_mock),
+        patch("huly_cli.client.HulyClient.tx", tx_mock),
+    ):
+        result = runner.invoke(
+            app, ["labels", "create", "--title", "Bug", "--project", "TP"]
+        )
+
+    assert result.exit_code == 0, result.output
+    create_tx = tx_mock.await_args.args[0]
+    assert create_tx["_class"] == "core:class:TxCreateDoc"
+    assert create_tx["objectClass"] == "tags:class:TagReference"
+
+
+def test_labels_create_project_not_found_exits_nonzero():
+    find_mock = AsyncMock(return_value=[])
+    tx_mock = AsyncMock(return_value={})
+
+    with (
+        _auth_patch(),
+        patch("huly_cli.client.HulyClient.find_all", find_mock),
+        patch("huly_cli.client.HulyClient.tx", tx_mock),
+    ):
+        result = runner.invoke(
+            app, ["labels", "create", "--title", "Bug", "--project", "MISSING"]
+        )
+
+    assert result.exit_code == 1
+    tx_mock.assert_not_awaited()
+
+
+def test_labels_update_writes_update_doc_tx():
+    tx_mock = AsyncMock(return_value={})
+
+    with (
+        _auth_patch(),
+        patch("huly_cli.client.HulyClient.find_all", new=AsyncMock(return_value=TAG_DETAIL_DATA)),
+        patch("huly_cli.client.HulyClient.tx", tx_mock),
+    ):
+        result = runner.invoke(
+            app, ["labels", "update", "t1", "--title", "Feature"]
+        )
+
+    assert result.exit_code == 0, result.output
+    update_tx = tx_mock.await_args.args[0]
+    assert update_tx["_class"] == "core:class:TxUpdateDoc"
+    assert update_tx["objectClass"] == "tags:class:TagReference"
+    assert update_tx["operations"]["title"] == "Feature"
+
+
+def test_labels_update_no_fields_warns():
+    tx_mock = AsyncMock(return_value={})
+
+    with (
+        _auth_patch(),
+        patch("huly_cli.client.HulyClient.find_all", new=AsyncMock(return_value=TAG_DETAIL_DATA)),
+        patch("huly_cli.client.HulyClient.tx", tx_mock),
+    ):
+        result = runner.invoke(app, ["labels", "update", "t1"])
+
+    assert result.exit_code == 0, result.output
+    tx_mock.assert_not_awaited()
+
+
+def test_labels_update_not_found_exits_nonzero():
+    find_mock = AsyncMock(return_value=[])
+    tx_mock = AsyncMock(return_value={})
+
+    with (
+        _auth_patch(),
+        patch("huly_cli.client.HulyClient.find_all", find_mock),
+        patch("huly_cli.client.HulyClient.tx", tx_mock),
+    ):
+        result = runner.invoke(
+            app, ["labels", "update", "missing-id", "--title", "X"]
+        )
+
+    assert result.exit_code == 1
+    tx_mock.assert_not_awaited()
+
+
+def test_labels_delete_removes_label():
+    tx_mock = AsyncMock(return_value={})
+
+    with (
+        _auth_patch(),
+        patch("huly_cli.client.HulyClient.find_all", new=AsyncMock(return_value=TAG_DETAIL_DATA)),
+        patch("huly_cli.client.HulyClient.tx", tx_mock),
+    ):
+        result = runner.invoke(app, ["labels", "delete", "t1"])
+
+    assert result.exit_code == 0, result.output
+    assert "deleted" in result.output.lower()
+    delete_tx = tx_mock.await_args.args[0]
+    assert delete_tx["_class"] == "core:class:TxRemoveDoc"
+    assert delete_tx["objectClass"] == "tags:class:TagReference"
+    assert delete_tx["objectId"] == "t1"
+
+
+def test_labels_delete_not_found_exits_nonzero():
+    find_mock = AsyncMock(return_value=[])
+    tx_mock = AsyncMock(return_value={})
+
+    with (
+        _auth_patch(),
+        patch("huly_cli.client.HulyClient.find_all", find_mock),
+        patch("huly_cli.client.HulyClient.tx", tx_mock),
+    ):
+        result = runner.invoke(app, ["labels", "delete", "missing-id"])
+
+    assert result.exit_code == 1
+    tx_mock.assert_not_awaited()
+
+
+# ── issues create with new flags ──────────────────────────────────────────────
+
+
+def _issue_create_find_side_effects(*, extra_finds=None):
+    """Build find_all side_effect list for a minimal issues create invocation.
+
+    Order: project lookup, issues-for-rank.
+    extra_finds are inserted after project lookup (before rank).
+    """
+    effects = list(PROJECT_DATA)  # single-element list for project
+    result = [PROJECT_DATA]
+    if extra_finds:
+        result.extend(extra_finds)
+    # issues for rank (empty → fallback rank)
+    result.append([])
+    return result
+
+
+def test_issues_create_with_due_date():
+    find_mock = AsyncMock(side_effect=_issue_create_find_side_effects())
+    tx_mock = AsyncMock(side_effect=[
+        {"object": {"sequence": 5}},  # sequence increment
+        {},  # issue create
+    ])
+
+    with (
+        _auth_patch(),
+        patch("huly_cli.client.HulyClient.find_all", find_mock),
+        patch("huly_cli.client.HulyClient.tx", tx_mock),
+    ):
+        result = runner.invoke(
+            app,
+            ["issues", "create", "--title", "Test", "--project", "TP", "--due-date", "2024-06-15"],
+        )
+
+    assert result.exit_code == 0, result.output
+    # The issue create tx is the second tx call
+    create_tx = tx_mock.await_args_list[1].args[0]
+    assert create_tx["attributes"]["dueDate"] == 1718409600000
+
+
+def test_issues_create_with_component():
+    component_find = [{"_id": "comp1", "label": "Auth Service", "space": "proj1"}]
+    find_mock = AsyncMock(
+        side_effect=_issue_create_find_side_effects(extra_finds=[component_find])
+    )
+    tx_mock = AsyncMock(side_effect=[
+        {"object": {"sequence": 5}},
+        {},
+    ])
+
+    with (
+        _auth_patch(),
+        patch("huly_cli.client.HulyClient.find_all", find_mock),
+        patch("huly_cli.client.HulyClient.tx", tx_mock),
+    ):
+        result = runner.invoke(
+            app,
+            ["issues", "create", "--title", "Test", "--project", "TP", "--component", "Auth Service"],
+        )
+
+    assert result.exit_code == 0, result.output
+    create_tx = tx_mock.await_args_list[1].args[0]
+    assert create_tx["attributes"]["component"] == "comp1"
+
+
+def test_issues_create_with_label():
+    # Label resolve returns [] (no existing tag), then attach emits a tx
+    label_find = [{"_id": "tr1", "tag": "tag-bug", "title": "Bug", "attachedTo": "other"}]
+    find_mock = AsyncMock(
+        side_effect=[
+            PROJECT_DATA,  # project lookup
+            [],  # issues for rank
+            label_find,  # _resolve_label_tag
+        ]
+    )
+    tx_mock = AsyncMock(side_effect=[
+        {"object": {"sequence": 5}},  # sequence increment
+        {},  # issue create
+        {},  # tag attach
+    ])
+
+    with (
+        _auth_patch(),
+        patch("huly_cli.client.HulyClient.find_all", find_mock),
+        patch("huly_cli.client.HulyClient.tx", tx_mock),
+    ):
+        result = runner.invoke(
+            app,
+            ["issues", "create", "--title", "Test", "--project", "TP", "--label", "Bug"],
+        )
+
+    assert result.exit_code == 0, result.output
+    # Third tx call is the tag attachment
+    tag_tx = tx_mock.await_args_list[2].args[0]
+    assert tag_tx["_class"] == "core:class:TxCreateDoc"
+    assert tag_tx["objectClass"] == "tags:class:TagReference"
+    assert tag_tx["attributes"]["title"] == "Bug"
+
+
+# ── issues update with new flags ──────────────────────────────────────────────
+
+
+def test_issues_update_with_due_date():
+    find_mock = AsyncMock(return_value=ISSUE_DATA)
+    tx_mock = AsyncMock(return_value={})
+
+    with (
+        _auth_patch(),
+        patch("huly_cli.client.HulyClient.find_all", find_mock),
+        patch("huly_cli.client.HulyClient.tx", tx_mock),
+    ):
+        result = runner.invoke(
+            app, ["issues", "update", "TP-1", "--due-date", "2024-06-15"]
+        )
+
+    assert result.exit_code == 0, result.output
+    update_tx = tx_mock.await_args.args[0]
+    assert update_tx["operations"]["dueDate"] == 1718409600000
+
+
+def test_issues_update_clear_due_date():
+    find_mock = AsyncMock(return_value=ISSUE_DATA)
+    tx_mock = AsyncMock(return_value={})
+
+    with (
+        _auth_patch(),
+        patch("huly_cli.client.HulyClient.find_all", find_mock),
+        patch("huly_cli.client.HulyClient.tx", tx_mock),
+    ):
+        result = runner.invoke(
+            app, ["issues", "update", "TP-1", "--due-date", ""]
+        )
+
+    assert result.exit_code == 0, result.output
+    update_tx = tx_mock.await_args.args[0]
+    assert update_tx["operations"]["dueDate"] is None
+
+
+def test_issues_update_with_component():
+    component_find = [{"_id": "comp1", "label": "Auth Service", "space": "proj1"}]
+    find_mock = AsyncMock(side_effect=[ISSUE_DATA, component_find])
+    tx_mock = AsyncMock(return_value={})
+
+    with (
+        _auth_patch(),
+        patch("huly_cli.client.HulyClient.find_all", find_mock),
+        patch("huly_cli.client.HulyClient.tx", tx_mock),
+    ):
+        result = runner.invoke(
+            app, ["issues", "update", "TP-1", "--component", "Auth Service"]
+        )
+
+    assert result.exit_code == 0, result.output
+    update_tx = tx_mock.await_args.args[0]
+    assert update_tx["operations"]["component"] == "comp1"
+
+
+def test_issues_update_clear_component():
+    find_mock = AsyncMock(return_value=ISSUE_DATA)
+    tx_mock = AsyncMock(return_value={})
+
+    with (
+        _auth_patch(),
+        patch("huly_cli.client.HulyClient.find_all", find_mock),
+        patch("huly_cli.client.HulyClient.tx", tx_mock),
+    ):
+        result = runner.invoke(
+            app, ["issues", "update", "TP-1", "--component", ""]
+        )
+
+    assert result.exit_code == 0, result.output
+    update_tx = tx_mock.await_args.args[0]
+    assert update_tx["operations"]["component"] is None
+
+
+def test_issues_update_with_label():
+    label_find = [{"_id": "tr1", "tag": "tag-bug", "title": "Bug", "attachedTo": "other"}]
+    find_mock = AsyncMock(side_effect=[ISSUE_DATA, label_find])
+    tx_mock = AsyncMock(side_effect=[
+        {},  # tag attach
+        {},  # (no update tx since only labels, no operations)
+    ])
+
+    with (
+        _auth_patch(),
+        patch("huly_cli.client.HulyClient.find_all", find_mock),
+        patch("huly_cli.client.HulyClient.tx", tx_mock),
+    ):
+        result = runner.invoke(
+            app, ["issues", "update", "TP-1", "--label", "Bug"]
+        )
+
+    assert result.exit_code == 0, result.output
+    # First tx call is the tag attachment
+    tag_tx = tx_mock.await_args_list[0].args[0]
+    assert tag_tx["_class"] == "core:class:TxCreateDoc"
+    assert tag_tx["objectClass"] == "tags:class:TagReference"
+    assert tag_tx["attributes"]["title"] == "Bug"
 
 
 # ── JSON output mode ───────────────────────────────────────────────────────────

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -482,7 +482,6 @@ def _issue_create_find_side_effects(*, extra_finds=None):
     Order: project lookup, issues-for-rank.
     extra_finds are inserted after project lookup (before rank).
     """
-    effects = list(PROJECT_DATA)  # single-element list for project
     result = [PROJECT_DATA]
     if extra_finds:
         result.extend(extra_finds)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -218,28 +218,51 @@ class TestPersonAccount:
 class TestTagReference:
     def test_tag_reference_from_api(self):
         raw = {"_id": "t1", "tag": "tag-id", "title": "Sprint 1", "attachedTo": "issue1"}
-        # TagReference does not have _id in current model — it uses tag/title/attachedTo
         tag = TagReference.model_validate(raw)
+        assert tag.id == "t1"
         assert tag.tag == "tag-id"
         assert tag.title == "Sprint 1"
         assert tag.attached_to == "issue1"
 
     def test_tag_reference_defaults(self):
-        raw = {"tag": "t", "title": "Label"}
+        raw = {"_id": "t2", "tag": "t", "title": "Label"}
         tag = TagReference.model_validate(raw)
         assert tag.attached_to == ""
+        assert tag.space == ""
+        assert tag.color is None
+        assert tag.created_on == 0
 
     def test_tag_reference_accepts_null_tag(self):
         """Regression test for issue #16: API may return null for tag."""
-        raw = {"tag": None, "title": "Label"}
+        raw = {"_id": "t3", "tag": None, "title": "Label"}
         tag = TagReference.model_validate(raw)
         assert tag.tag is None
 
     def test_tag_reference_accepts_null_title(self):
         """Regression test for issue #16: API may return null for title."""
-        raw = {"tag": "t", "title": None}
+        raw = {"_id": "t4", "tag": "t", "title": None}
         tag = TagReference.model_validate(raw)
         assert tag.title is None
+
+    def test_tag_reference_full_fields(self):
+        raw = {
+            "_id": "t5",
+            "tag": "tag-id",
+            "title": "Bug",
+            "color": 9,
+            "attachedTo": "issue99",
+            "space": "proj-1",
+            "createdBy": "user1",
+            "createdOn": 1700000000000,
+            "modifiedBy": "user2",
+            "modifiedOn": 1700000001000,
+        }
+        tag = TagReference.model_validate(raw)
+        assert tag.id == "t5"
+        assert tag.color == 9
+        assert tag.space == "proj-1"
+        assert tag.created_by == "user1"
+        assert tag.modified_on == 1700000001000
 
 
 # ── Dict constants ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Full labels CRUD: `labels get`, `labels create`, `labels update`, `labels delete`
- `--due-date` flag on `issues create` and `issues update` (YYYY-MM-DD format, epoch ms conversion)
- `--component` flag on `issues create` and `issues update` (fuzzy name matching)
- `--label` flag on `issues create` and `issues update` (repeatable, attaches TagReference docs)
- Updated `TagReference` model with `id`, `color`, `space`, and timestamp fields

Closes #33

## Test plan
- [x] 17 new command-level tests covering all new commands and flags
- [x] Updated model tests for TagReference with new fields
- [x] All 260 tests pass