### PR TITLE
feat: add documents discovery filters and title resolvers (#37)

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,17 @@ huly issues delete DEMO-1
 ### Documents
 
 ```bash
+# List and filter
 huly documents list --space "Engineering"
+huly documents list --title-contains "RAG"       # case-insensitive substring
+huly documents list --parent DOC_ID              # direct children only
+
+# Find a doc without knowing its ID
+huly documents search "rag template"             # alias for --title-contains
+huly documents get --title "Design Doc"          # errors if title is ambiguous
+huly documents describe --title "Design Doc"
+
+# Create / update / describe / delete by ID
 huly documents create --space "Engineering" --title "Design Doc"
 huly documents describe DOC_ID --set "# Design\n\nContent here."
 huly documents describe DOC_ID --set-file ./doc.md

--- a/skills/huly-cli/SKILL.md
+++ b/skills/huly-cli/SKILL.md
@@ -147,7 +147,7 @@ Current implemented command groups:
 - `auth` — login, status
 - `projects` — list, get
 - `issues` — list, get, create, update, delete, describe
-- `documents` — list, get, create, update, delete, describe
+- `documents` — list, get, create, update, delete, describe, search
 - `components` — list, get, create, update, delete
 - `milestones` — list, get, create, update, delete
 - `templates` — list, get, describe (read/write)
@@ -177,6 +177,27 @@ Issue-specific fields supported on create/update:
 - `--component` — name or ID (use "" to unset on update)
 - `--label` — repeatable flag to attach labels
 - `--description` — markdown text (create only)
+
+Document discovery helpers (avoid the list → jq → copy-ID dance):
+
+- `documents list --title-contains TEXT` — case-insensitive title substring
+  (client-side filter over the fetched page; bump `-n` in large workspaces)
+- `documents list --parent DOC_ID` — direct children of a given document
+- `documents get --title TITLE` / `documents describe --title TITLE` —
+  resolve by case-insensitive exact title; errors with a match table if
+  multiple documents share the same title
+- `documents search "query"` — thin wrapper around `--title-contains`;
+  will swap to workspace fulltext once that lands
+
+Examples:
+
+```bash
+huly documents list --title-contains "RAG" -n 200
+huly documents list --parent DOC_ROOT_ID
+huly documents get --title "Design Doc"
+huly documents describe --title "Design Doc"
+huly documents search "rag template"
+```
 
 ### 5. Use repo facts when relevant
 

--- a/src/huly_cli/commands/documents.py
+++ b/src/huly_cli/commands/documents.py
@@ -94,6 +94,29 @@ async def _find_document_by_id(client: HulyClient, doc_id: str) -> Document:
     return Document.model_validate(raw[0])
 
 
+async def _resolve_document_by_title(client: HulyClient, title: str) -> Document:
+    """Resolve a document by case-insensitive exact title match.
+
+    Raises NotFoundError if no match, or HulyError with a formatted match table
+    if multiple documents share the same title.
+    """
+    raw = await client.find_all(
+        "document:class:Document",
+        options={"limit": 500},
+    )
+    title_lower = title.lower()
+    matches = [d for d in raw if (d.get("title") or "").lower() == title_lower]
+    if not matches:
+        raise NotFoundError(f"No document matched title '{title}'.")
+    if len(matches) > 1:
+        rows = "\n".join(f"  - {d.get('title', '')}  (id: {d['_id']})" for d in matches)
+        raise HulyError(
+            f"Multiple documents matched title '{title}':\n{rows}\n"
+            "Pass the document ID directly to disambiguate."
+        )
+    return Document.model_validate(matches[0])
+
+
 # ── Commands ──────────────────────────────────────────────────────────────────
 
 
@@ -104,12 +127,26 @@ def docs_list(
         str | None,
         typer.Option("--space", "-s", help="Filter by teamspace name."),
     ] = None,
+    title_contains: Annotated[
+        str | None,
+        typer.Option(
+            "--title-contains",
+            help=(
+                "Case-insensitive substring match on title. Applied client-side "
+                "after fetching --limit records; bump -n for larger workspaces."
+            ),
+        ),
+    ] = None,
+    parent: Annotated[
+        str | None,
+        typer.Option("--parent", help="List only direct children of this document ID."),
+    ] = None,
     limit: Annotated[
         int,
         typer.Option("--limit", "-n", help="Maximum number of documents to return."),
     ] = 50,
 ) -> None:
-    """List documents, with optional teamspace filter."""
+    """List documents, with optional teamspace / parent / title filters."""
     overrides: dict = ctx.obj or {}
     config = load_config(
         url_override=overrides.get("url"),
@@ -125,6 +162,8 @@ def docs_list(
             if space:
                 space_id = await _resolve_teamspace_by_name(client, space)
                 query["space"] = space_id
+            if parent:
+                query["parent"] = parent
 
             raw = await client.find_all(
                 "document:class:Document",
@@ -132,6 +171,10 @@ def docs_list(
                 options={"limit": limit},
             )
             docs = [Document.model_validate(doc) for doc in raw]
+
+            if title_contains:
+                needle = title_contains.lower()
+                docs = [d for d in docs if needle in (d.title or "").lower()]
 
         return [_doc_to_row(d, space_map) for d in docs]
 
@@ -150,9 +193,23 @@ def docs_list(
 @app.command("get")
 def docs_get(
     ctx: typer.Context,
-    doc_id: str = typer.Argument(..., help="Document internal ID."),
+    doc_id: str | None = typer.Argument(
+        None,
+        help="Document internal ID (omit when using --title).",
+    ),
+    title: Annotated[
+        str | None,
+        typer.Option(
+            "--title",
+            help="Resolve by case-insensitive exact title match instead of ID.",
+        ),
+    ] = None,
 ) -> None:
-    """Get details of a document."""
+    """Get details of a document by ID or by --title."""
+    if (doc_id is None) == (title is None):
+        print_error("Provide either DOC_ID or --title, not both.")
+        raise typer.Exit(1)
+
     overrides: dict = ctx.obj or {}
     config = load_config(
         url_override=overrides.get("url"),
@@ -162,7 +219,10 @@ def docs_get(
     async def _run() -> dict[str, Any]:
         auth = await ensure_auth(config)
         async with HulyClient(config, auth) as client:
-            doc = await _find_document_by_id(client, doc_id)
+            if title is not None:
+                doc = await _resolve_document_by_title(client, title)
+            else:
+                doc = await _find_document_by_id(client, doc_id)  # type: ignore[arg-type]
             space_map = await _fetch_teamspace_map(client)
         return _doc_to_detail(doc, space_map)
 
@@ -178,7 +238,7 @@ def docs_get(
         print_error(e.message)
         raise typer.Exit(1) from e
 
-    print_item(data, title=f"Document: {data.get('title', doc_id)}")
+    print_item(data, title=f"Document: {data.get('title', doc_id or title)}")
 
 
 @app.command("create")
@@ -295,7 +355,17 @@ def docs_update(
 @app.command("describe")
 def docs_describe(
     ctx: typer.Context,
-    doc_id: str = typer.Argument(..., help="Document internal ID."),
+    doc_id: str | None = typer.Argument(
+        None,
+        help="Document internal ID (omit when using --title).",
+    ),
+    title: Annotated[
+        str | None,
+        typer.Option(
+            "--title",
+            help="Resolve by case-insensitive exact title match instead of ID.",
+        ),
+    ] = None,
     raw: Annotated[
         bool,
         typer.Option("--raw", help="Show raw ProseMirror JSON instead of rendered markdown."),
@@ -309,7 +379,7 @@ def docs_describe(
         typer.Option("--set-file", help="Set content from a markdown file path."),
     ] = None,
 ) -> None:
-    """Read or update the content of a document.
+    """Read or update the content of a document by ID or by --title.
 
     By default, reads and displays the content. Use --set or --set-file to write.
     """
@@ -317,11 +387,20 @@ def docs_describe(
         print_error("Use either --set or --set-file, not both.")
         raise typer.Exit(1)
 
+    if (doc_id is None) == (title is None):
+        print_error("Provide either DOC_ID or --title, not both.")
+        raise typer.Exit(1)
+
     overrides: dict = ctx.obj or {}
     config = load_config(
         url_override=overrides.get("url"),
         workspace_override=overrides.get("workspace"),
     )
+
+    async def _resolve(client: HulyClient) -> Document:
+        if title is not None:
+            return await _resolve_document_by_title(client, title)
+        return await _find_document_by_id(client, doc_id)  # type: ignore[arg-type]
 
     # ── Write path ────────────────────────────────────────────────────────
     if set_text is not None or set_file is not None:
@@ -341,7 +420,7 @@ def docs_describe(
             auth = await ensure_auth(config)
             async with HulyClient(config, auth) as client:
                 markup = markdown_to_prosemirror(markdown_content or "")
-                doc = await _find_document_by_id(client, doc_id)
+                doc = await _resolve(client)
                 if doc.content and not _is_inline_markup(doc.content):
                     ok = await client.set_content(
                         "document:class:Document", doc.id, "content", doc.content, markup
@@ -369,7 +448,7 @@ def docs_describe(
                             "modifiedOn": int(time.time() * 1000),
                         }
                     )
-            return doc.title or doc_id
+            return doc.title or doc.id
 
         try:
             title_label = asyncio.run(_write())
@@ -387,22 +466,22 @@ def docs_describe(
         return
 
     # ── Read path ─────────────────────────────────────────────────────────
-    async def _run() -> tuple[str, str | None]:
+    async def _run() -> tuple[str, str, str | None]:
         auth = await ensure_auth(config)
         async with HulyClient(config, auth) as client:
-            doc = await _find_document_by_id(client, doc_id)
+            doc = await _resolve(client)
             if not doc.content:
-                return doc.title or doc_id, None
+                return doc.id, doc.title or doc.id, None
             if _is_inline_markup(doc.content):
                 content = doc.content
             else:
                 content = await client.get_content(
                     "document:class:Document", doc.id, "content", doc.content
                 )
-        return doc.title or doc_id, content
+        return doc.id, doc.title or doc.id, content
 
     try:
-        title_label, content = asyncio.run(_run())
+        resolved_id, title_label, content = asyncio.run(_run())
     except NotFoundError as e:
         print_error(e.message)
         raise typer.Exit(1) from e
@@ -419,12 +498,12 @@ def docs_describe(
 
     if is_json_mode():
         if raw:
-            print(json.dumps({"ok": True, "id": doc_id, "content_raw": content}))
+            print(json.dumps({"ok": True, "id": resolved_id, "content_raw": content}))
         else:
             from huly_cli.markup import prosemirror_to_markdown
 
             md = prosemirror_to_markdown(content)
-            print(json.dumps({"ok": True, "id": doc_id, "content": md}))
+            print(json.dumps({"ok": True, "id": resolved_id, "content": md}))
         return
 
     if raw:
@@ -447,6 +526,51 @@ def docs_describe(
 
             plain = prosemirror_to_text(content)
             console.print(Panel(plain or "(empty content)", title=f"Content: {title_label}"))
+
+
+@app.command("search")
+def docs_search(
+    ctx: typer.Context,
+    query: str = typer.Argument(..., help="Case-insensitive title substring to match."),
+    limit: Annotated[
+        int,
+        typer.Option("--limit", "-n", help="Maximum number of documents to scan."),
+    ] = 200,
+) -> None:
+    """Search documents by title substring.
+
+    Currently a client-side title-substring filter over `find-all`. The backend
+    will swap to the workspace fulltext endpoint once that command lands.
+    """
+    overrides: dict = ctx.obj or {}
+    config = load_config(
+        url_override=overrides.get("url"),
+        workspace_override=overrides.get("workspace"),
+    )
+
+    async def _run() -> list[dict[str, Any]]:
+        auth = await ensure_auth(config)
+        async with HulyClient(config, auth) as client:
+            space_map = await _fetch_teamspace_map(client)
+            raw = await client.find_all(
+                "document:class:Document",
+                options={"limit": limit},
+            )
+            docs = [Document.model_validate(doc) for doc in raw]
+            needle = query.lower()
+            docs = [d for d in docs if needle in (d.title or "").lower()]
+        return [_doc_to_row(d, space_map) for d in docs]
+
+    try:
+        rows = asyncio.run(_run())
+    except AuthError as e:
+        print_error(e.message, hint="Run 'huly auth login' to authenticate.")
+        raise typer.Exit(2) from e
+    except HulyError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+
+    print_list(rows, columns=["title", "space", "parent", "id"], title=f"Search: {query}")
 
 
 @app.command("delete")

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -769,6 +769,168 @@ def test_documents_list_shows_space():
     assert "Engineering" in result.output
 
 
+# ── documents discovery filters (#37) ─────────────────────────────────────────
+
+
+def _doc(doc_id: str, title: str, parent: str = "document:ids:NoParent") -> dict:
+    return {
+        "_id": doc_id,
+        "title": title,
+        "content": "",
+        "space": "ts1",
+        "parent": parent,
+        "attachments": 0,
+        "labels": 0,
+        "comments": 0,
+        "rank": "",
+        "createdBy": "",
+        "createdOn": 0,
+        "modifiedBy": "",
+        "modifiedOn": 0,
+    }
+
+
+def test_documents_list_title_contains_filters_case_insensitive():
+    """--title-contains should be a case-insensitive substring filter on title."""
+    docs = [
+        _doc("doc-1", "RAG Template"),
+        _doc("doc-2", "Unrelated note"),
+        _doc("doc-3", "lower rag match"),
+    ]
+    find_mock = AsyncMock(side_effect=[TEAMSPACE_DATA, docs])
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["documents", "list", "--title-contains", "RAG"])
+    assert result.exit_code == 0, result.output
+    assert "RAG Template" in result.output
+    assert "lower rag match" in result.output
+    assert "Unrelated note" not in result.output
+
+
+def test_documents_list_parent_filter_passes_parent_to_find_all():
+    """--parent PARENT_ID should forward parent into the find-all query."""
+    find_mock = AsyncMock(
+        side_effect=[TEAMSPACE_DATA, [_doc("doc-child", "Child doc", "doc-parent")]]
+    )
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["documents", "list", "--parent", "doc-parent"])
+    assert result.exit_code == 0, result.output
+    assert "Child doc" in result.output
+    # Second find_all call is the documents query; it should include parent in its query arg
+    docs_call = find_mock.await_args_list[1]
+    assert docs_call.kwargs["query"]["parent"] == "doc-parent"
+
+
+def test_documents_get_by_title_resolves_unique_match():
+    """documents get --title TITLE returns the doc when exactly one match exists."""
+    docs = [
+        _doc("doc-1", "My RAG Template"),
+        _doc("doc-2", "Something else"),
+    ]
+    # Order in docs_get: _resolve_document_by_title find_all, then teamspace find_all
+    find_mock = AsyncMock(side_effect=[docs, TEAMSPACE_DATA])
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["documents", "get", "--title", "my rag template"])
+    assert result.exit_code == 0, result.output
+    assert "My RAG Template" in result.output
+    assert "doc-1" in result.output
+
+
+def test_documents_get_by_title_errors_on_multiple_matches():
+    """Multiple title matches must error with a table of (title, id) pairs — no silent pick."""
+    docs = [
+        _doc("doc-1", "Design Doc"),
+        _doc("doc-2", "Design Doc"),
+    ]
+    find_mock = AsyncMock(return_value=docs)
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["documents", "get", "--title", "Design Doc"])
+    assert result.exit_code == 1
+    assert "multiple" in result.output.lower()
+    assert "doc-1" in result.output
+    assert "doc-2" in result.output
+
+
+def test_documents_get_by_title_not_found_exits_nonzero():
+    """documents get --title with no match should exit 1 with a clear message."""
+    find_mock = AsyncMock(return_value=[_doc("doc-1", "Something")])
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["documents", "get", "--title", "nonexistent"])
+    assert result.exit_code == 1
+    assert "no document matched" in result.output.lower()
+
+
+def test_documents_get_requires_doc_id_or_title():
+    """documents get called with neither DOC_ID nor --title must exit 1."""
+    with _auth_patch():
+        result = runner.invoke(app, ["documents", "get"])
+    assert result.exit_code == 1
+    assert "either" in result.output.lower()
+
+
+def test_documents_get_rejects_both_doc_id_and_title():
+    """documents get with both DOC_ID and --title must exit 1."""
+    with _auth_patch():
+        result = runner.invoke(app, ["documents", "get", "doc-1", "--title", "Thing"])
+    assert result.exit_code == 1
+    assert "either" in result.output.lower()
+
+
+def test_documents_describe_by_title_resolves_unique_match():
+    """documents describe --title TITLE reads the doc content when exactly one match exists."""
+    docs = [
+        _doc("doc-1", "My RAG Template"),
+    ]
+    # describe read path: resolve title, then since content is empty, it short-circuits
+    find_mock = AsyncMock(return_value=docs)
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["documents", "describe", "--title", "my rag template"])
+    # Empty content triggers "No content available" error; we still verified the title resolved
+    assert result.exit_code == 1
+    assert "My RAG Template" in result.output
+
+
+def test_documents_describe_by_title_errors_on_multiple_matches():
+    """documents describe --title with duplicate titles must surface all matches."""
+    docs = [
+        _doc("doc-1", "Design Doc"),
+        _doc("doc-2", "Design Doc"),
+    ]
+    find_mock = AsyncMock(return_value=docs)
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["documents", "describe", "--title", "Design Doc"])
+    assert result.exit_code == 1
+    assert "multiple" in result.output.lower()
+    assert "doc-1" in result.output
+    assert "doc-2" in result.output
+
+
+def test_documents_search_filters_by_title_substring():
+    """documents search QUERY wraps list with a client-side title-substring filter."""
+    docs = [
+        _doc("doc-1", "RAG Template"),
+        _doc("doc-2", "Unrelated note"),
+        _doc("doc-3", "Another RAG doc"),
+    ]
+    # search calls find_all twice: once for teamspaces, once for documents
+    find_mock = AsyncMock(side_effect=[TEAMSPACE_DATA, docs])
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["documents", "search", "rag"])
+    assert result.exit_code == 0, result.output
+    assert "RAG Template" in result.output
+    assert "Another RAG doc" in result.output
+    assert "Unrelated note" not in result.output
+
+
+def test_documents_search_empty_result_exits_zero():
+    """documents search with no title matches should still exit 0."""
+    docs = [_doc("doc-1", "Unrelated note")]
+    find_mock = AsyncMock(side_effect=[TEAMSPACE_DATA, docs])
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["documents", "search", "nothing matches"])
+    assert result.exit_code == 0, result.output
+    assert "Unrelated note" not in result.output
+
+
 # ── components list ────────────────────────────────────────────────────────────
 
 COMPONENT_DATA = [


### PR DESCRIPTION
## Summary

Adds discovery filters and title-based resolvers to the `documents` command group so agents don't have to `list → --json → jq → copy ID → get/describe`. All three additions are client-side over the existing `find-all` Document query — no new RPCs.

## Changes

- `documents list --title-contains TEXT` — case-insensitive substring match on title, applied client-side after `find-all`. Help text notes callers should bump `-n` in large workspaces since the filter runs over the fetched page, not the whole workspace.
- `documents list --parent DOC_ID` — forwards `parent` into the `find-all` query so callers can walk a hierarchy without fetching the whole workspace.
- `documents get --title TITLE` and `documents describe --title TITLE` — case-insensitive exact title → ID resolver. If multiple documents share the title, exits 1 with a formatted `(title, id)` table rather than silently picking one. Argument `DOC_ID` is now optional; exactly one of `{DOC_ID, --title}` must be provided.
- `documents search "query"` — new command; currently a client-side title-substring filter (thin wrapper over `--title-contains`). Will swap the backend to `/search-fulltext` once #41 lands.

Docs updated: `README.md` (documents usage examples) and `skills/huly-cli/SKILL.md` (document discovery helpers block + documents row in command groups).

Scope stayed within `src/huly_cli/commands/documents.py`, `tests/test_commands.py`, `README.md`, and `skills/huly-cli/SKILL.md`. No changes to `client.py`, `output.py`, or any other command module.

## Test plan

- [x] `uv run ruff format . && uv run ruff check .` — clean
- [x] `uv run pytest -x` — 277 passed (266 before + 11 new command-layer tests)
- [x] New tests cover: title-contains filter, parent filter (asserts `parent` forwarded into the find-all query), title resolver unique match (`get` + `describe`), title resolver multiple-match error with match table, title resolver not-found, both-args error, neither-args error, search happy path, search empty result.

Closes #37