### PR TITLE
feat: add top-level search command and issues search wrapper (#41)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ Additional capabilities:
   (repeatable `--label` flag on create/update)
 - **Status filtering**: `issues list --status <name>` resolves against the live
   workspace status index, supporting custom statuses
+- **Fulltext search**: `huly search "query"` searches titles and body content
+  across every class in the workspace, with optional `--class` filters and a
+  class-scoped wrapper at `huly issues search`.
 - **JSON mode**: `huly --json <command>` for machine-readable output
 - **Self-upgrade**: `huly upgrade` to update from PyPI
 - **Shell completion**: `huly --install-completion`
@@ -232,6 +235,31 @@ huly templates describe TEMPLATE_ID --set "## Template description"
 ```bash
 huly members list
 ```
+
+### Search
+
+```bash
+# Fulltext search across every class in the workspace.
+huly search "milestone 3"
+
+# Limit results and filter client-side by fully qualified class.
+huly search "roadmap" --limit 10 --class tracker:class:Issue
+huly search "onboarding" --class document:class:Document --class tracker:class:Issue
+
+# Class-scoped wrapper for issues.
+huly issues search "login bug"
+
+# JSON output for scripting.
+huly --json search "project" --limit 5
+huly search "project" --limit 5 --json
+```
+
+Notes:
+
+- The `--class` filter is applied client-side on the returned
+  `doc._class`; the server's equivalent query parameter is not reliable.
+- Results are ranked by descending relevance `score`. Omitting `--class`
+  returns a mixed result set across issues, documents, templates, etc.
 
 ### JSON mode
 

--- a/skills/huly-cli/SKILL.md
+++ b/skills/huly-cli/SKILL.md
@@ -146,13 +146,14 @@ Current implemented command groups:
 
 - `auth` — login, status
 - `projects` — list, get
-- `issues` — list, get, create, update, delete, describe
+- `issues` — list, get, create, update, delete, describe, search
 - `documents` — list, get, create, update, delete, describe
 - `components` — list, get, create, update, delete
 - `milestones` — list, get, create, update, delete
 - `templates` — list, get, describe (read/write)
 - `labels` — list, get, create, update, delete
 - `members` — list
+- `search` — top-level fulltext search across the whole workspace
 - `upgrade` — self-upgrade from PyPI
 
 Current live-validated CRUD coverage:
@@ -177,6 +178,35 @@ Issue-specific fields supported on create/update:
 - `--component` — name or ID (use "" to unset on update)
 - `--label` — repeatable flag to attach labels
 - `--description` — markdown text (create only)
+
+### Fulltext search
+
+```bash
+# Workspace-wide (mixes issues, documents, templates, etc.)
+huly search "milestone 3"
+
+# With a limit and a class filter.
+huly search "roadmap" --limit 10 --class tracker:class:Issue
+
+# Class-scoped wrapper for issues.
+huly issues search "login bug"
+
+# JSON envelope.
+huly --json search "project"
+```
+
+Important caveats for agents:
+
+- Repeatable `--class` filters are applied **client-side** on the returned
+  `doc._class`. The server's `&classes=` query parameter is not reliable,
+  so narrow locally rather than trusting server-side filtering.
+- Omitting `--class` returns a mixed result set ranked by descending
+  `score` — ideal when you don't yet know whether the answer lives in an
+  issue, a document, or a template.
+- The server response is known to arrive with a truncated trailing `}`.
+  The CLI parses the `docs` array directly via a regex workaround, so
+  `huly search` and `huly issues search` always return clean data — do
+  not hit the endpoint with raw `curl` and stock `json.loads`.
 
 ### 5. Use repo facts when relevant
 

--- a/src/huly_cli/client.py
+++ b/src/huly_cli/client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json as json_mod
+import re
 import time
 import urllib.parse
 from typing import Any
@@ -17,6 +18,19 @@ from huly_cli.output import print_warning
 # Retry settings for Collaborator RPC (server 500s)
 _RETRY_MAX_ATTEMPTS = 3
 _RETRY_BASE_DELAY = 1.0  # seconds; doubles each attempt
+
+
+def _doc_class(doc: dict[str, Any]) -> str | None:
+    """Extract the ``_class`` from a fulltext search hit.
+
+    Server hits carry the class as ``doc._class`` (nested one level) — the
+    top-level ``_class`` is the wrapper-document class, not the underlying
+    entity's.
+    """
+    inner = doc.get("doc")
+    if isinstance(inner, dict):
+        return inner.get("_class")
+    return None
 
 
 class HulyClient:
@@ -73,6 +87,70 @@ class HulyClient:
         """GET /api/v1/account/{workspace_id} — current user account info."""
         resp = await self._http.get(f"/api/v1/account/{self._auth.workspace_id}")
         return self._handle_response(resp)
+
+    async def fulltext_search(
+        self,
+        query: str,
+        limit: int = 25,
+        classes: list[str] | None = None,
+    ) -> list[dict[str, Any]]:
+        """Query the server fulltext index via GET /api/v1/search-fulltext.
+
+        The upstream server returns a JSON body whose closing brace is
+        truncated — ``Content-Length`` is correct but the tail is cut at
+        ``"total":1`` with the final ``}`` missing. Extracting the ``"docs":
+        [...]`` array with a regex sidesteps the truncation entirely (the
+        array itself is always complete, well-formed JSON).
+
+        ``classes`` filters client-side on each doc's ``doc._class`` because
+        the server's ``&classes=`` query parameter is not reliable.
+        """
+        params: list[tuple[str, str]] = [("query", query), ("limit", str(limit))]
+        resp = await self._http.get(
+            f"/api/v1/search-fulltext/{self._auth.workspace_id}",
+            params=params,
+        )
+
+        # Reuse the status-code handling from `_handle_response` but do NOT
+        # try to parse the body with ``resp.json()`` — it is truncated.
+        if resp.status_code in (401, 403):
+            raise AuthError(
+                f"Authentication failed (HTTP {resp.status_code}). Run 'huly auth login'."
+            )
+        if resp.status_code == 429:
+            retry_after_header = resp.headers.get("Retry-After")
+            if retry_after_header is not None:
+                try:
+                    retry_after = float(retry_after_header)
+                except ValueError:
+                    retry_after = 0.0
+            else:
+                try:
+                    retry_after = float(resp.headers.get("Retry-After-ms", 0)) / 1000.0
+                except ValueError:
+                    retry_after = 0.0
+            raise RateLimitError("Rate limit exceeded.", retry_after=retry_after)
+        if resp.status_code >= 500:
+            raise ServerError(f"Server error (HTTP {resp.status_code}): {resp.text[:200]}")
+        resp.raise_for_status()
+
+        body = resp.text
+        # DOTALL so ``.`` matches newlines that may appear inside titles.
+        match = re.search(r'"docs":(\[.*\])', body, flags=re.DOTALL)
+        if match is None:
+            return []
+        try:
+            docs = json_mod.loads(match.group(1))
+        except json_mod.JSONDecodeError:
+            return []
+        if not isinstance(docs, list):
+            return []
+        docs = [doc for doc in docs if isinstance(doc, dict)]
+
+        if classes:
+            wanted = set(classes)
+            docs = [doc for doc in docs if _doc_class(doc) in wanted]
+        return docs
 
     # ── Collaborator RPC ──────────────────────────────────────────────────────
 

--- a/src/huly_cli/commands/issues.py
+++ b/src/huly_cli/commands/issues.py
@@ -839,6 +839,46 @@ def issues_describe(
             console.print(Panel(plain or "(empty description)", title=f"Description: {ident}"))
 
 
+@app.command("search")
+def issues_search(
+    ctx: typer.Context,
+    query: str = typer.Argument(..., help="Search query."),
+    limit: Annotated[
+        int, typer.Option("--limit", "-n", help="Maximum number of hits to return.")
+    ] = 25,
+    json_output: Annotated[
+        bool,
+        typer.Option(
+            "--json",
+            help="Emit structured JSON output (id, class, title, score).",
+        ),
+    ] = False,
+) -> None:
+    """Fulltext-search issues only.
+
+    Thin wrapper over the top-level ``huly search`` that pre-fills
+    ``--class tracker:class:Issue``. Pairs with the parallel documents-search
+    wrapper owned by #37.
+    """
+    # Import lazily to avoid a circular dependency on main.py.
+    from huly_cli.commands.search import _emit, _run_search
+    from huly_cli.output import set_json_mode
+
+    if json_output:
+        set_json_mode(True)
+
+    try:
+        hits = asyncio.run(_run_search(ctx, query, limit, classes=["tracker:class:Issue"]))
+    except AuthError as e:
+        print_error(e.message, hint="Run 'huly auth login' to authenticate.")
+        raise typer.Exit(2) from e
+    except HulyError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+
+    _emit(hits, title=f"Issues search: {query}")
+
+
 @app.command("delete")
 def issues_delete(
     ctx: typer.Context,

--- a/src/huly_cli/commands/search.py
+++ b/src/huly_cli/commands/search.py
@@ -1,0 +1,124 @@
+"""Top-level ``huly search`` command — fulltext search across the workspace."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Annotated, Any
+
+import typer
+
+from huly_cli.auth import ensure_auth
+from huly_cli.client import HulyClient
+from huly_cli.config import load_config
+from huly_cli.errors import AuthError, HulyError
+from huly_cli.output import is_json_mode, print_error, print_list
+
+# ── Shared helpers ────────────────────────────────────────────────────────────
+
+
+def _hit_to_row(hit: dict[str, Any]) -> dict[str, Any]:
+    """Flatten a fulltext hit for the default human-readable table."""
+    inner = hit.get("doc") if isinstance(hit.get("doc"), dict) else {}
+    doc_id = inner.get("_id") or hit.get("id") or ""
+    cls = inner.get("_class") or ""
+    score = hit.get("score")
+    score_str = f"{float(score):.1f}" if isinstance(score, (int, float)) else ""
+    return {
+        "class": cls,
+        "id": str(doc_id),
+        "title": hit.get("title") or "",
+        "score": score_str,
+    }
+
+
+def _hit_to_json(hit: dict[str, Any]) -> dict[str, Any]:
+    """Structured envelope for ``--json`` — id, class, score, title."""
+    inner = hit.get("doc") if isinstance(hit.get("doc"), dict) else {}
+    return {
+        "id": inner.get("_id") or hit.get("id") or "",
+        "class": inner.get("_class") or "",
+        "title": hit.get("title") or "",
+        "score": hit.get("score"),
+    }
+
+
+async def _run_search(
+    ctx: typer.Context,
+    query: str,
+    limit: int,
+    classes: list[str] | None,
+) -> list[dict[str, Any]]:
+    """Fetch fulltext results from the server.
+
+    Returns the raw hit list so the caller can decide how to format.
+    """
+    overrides: dict = ctx.obj or {}
+    config = load_config(
+        url_override=overrides.get("url"),
+        workspace_override=overrides.get("workspace"),
+    )
+    auth = await ensure_auth(config)
+    async with HulyClient(config, auth) as client:
+        return await client.fulltext_search(query, limit=limit, classes=classes)
+
+
+def _emit(hits: list[dict[str, Any]], title: str) -> None:
+    """Emit hits — JSON envelope in ``--json`` mode, otherwise a table."""
+    if is_json_mode():
+        payload = [_hit_to_json(hit) for hit in hits]
+        print_list(payload, columns=["class", "id", "title", "score"], title=title)
+        return
+    rows = [_hit_to_row(hit) for hit in hits]
+    print_list(rows, columns=["class", "id", "title", "score"], title=title)
+
+
+# ── Command ──────────────────────────────────────────────────────────────────
+
+
+def search(
+    ctx: typer.Context,
+    query: str = typer.Argument(..., help="Search query."),
+    limit: Annotated[
+        int,
+        typer.Option("--limit", "-n", help="Maximum number of hits to return."),
+    ] = 25,
+    class_filter: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--class",
+            help=(
+                "Filter results by fully qualified class (e.g. "
+                "'tracker:class:Issue'). Repeatable. Filtered client-side."
+            ),
+        ),
+    ] = None,
+    json_output: Annotated[
+        bool,
+        typer.Option(
+            "--json",
+            help="Emit structured JSON output (id, class, title, score).",
+        ),
+    ] = False,
+) -> None:
+    """Fulltext search across the workspace.
+
+    Returns ranked results mixing all classes (issues, documents, templates,
+    etc.) by descending relevance score. Use ``--class`` to restrict to one
+    or more classes — filtering happens client-side because the server's
+    equivalent query parameter is unreliable.
+    """
+    if json_output:
+        from huly_cli.output import set_json_mode
+
+        set_json_mode(True)
+
+    try:
+        hits = asyncio.run(_run_search(ctx, query, limit, class_filter))
+    except AuthError as e:
+        print_error(e.message, hint="Run 'huly auth login' to authenticate.")
+        raise typer.Exit(2) from e
+    except HulyError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+
+    _emit(hits, title=f"Search: {query}")

--- a/src/huly_cli/main.py
+++ b/src/huly_cli/main.py
@@ -16,6 +16,7 @@ from huly_cli.commands import (
     members,
     milestones,
     projects,
+    search,
     templates,
 )
 from huly_cli.commands import upgrade as upgrade_cmd
@@ -38,6 +39,10 @@ app.add_typer(documents.app, name="documents")
 app.add_typer(components.app, name="components")
 app.add_typer(milestones.app, name="milestones")
 app.add_typer(templates.app, name="templates")
+app.command(
+    "search",
+    help="Fulltext search across the workspace (issues, documents, templates, ...).",
+)(search.search)
 app.command("upgrade", help="Upgrade huly-cli to the latest version from PyPI.")(
     upgrade_cmd.upgrade
 )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -403,3 +403,97 @@ async def test_find_all_drops_mixed_non_dict_rows(fake_config, fake_auth):
             result = await client.find_all("tracker:class:Issue")
     assert len(result) == 1
     assert result[0]["_id"] == "keep"
+
+
+# ── fulltext_search ───────────────────────────────────────────────────────────
+
+# Real server bodies are truncated: Content-Length is declared but the closing
+# ``}`` (and surrounding chars) are missing. Stock ``json.loads`` fails every
+# call. The workaround extracts the ``docs`` array directly with a regex.
+TRUNCATED_BODY = (
+    '{"docs":['
+    '{"id":"i1","title":"Fix login","doc":{"_id":"i1","_class":"tracker:class:Issue"},'
+    '"score":100.5,"iconComponent":"x"},'
+    '{"id":"d1","title":"Onboarding","doc":{"_id":"d1","_class":"document:class:Document"},'
+    '"score":42.0,"iconComponent":"x"}'
+    '],"total":1'  # ← no closing } here. This is the upstream bug.
+)
+
+
+async def test_fulltext_search_parses_truncated_body(fake_config, fake_auth):
+    """THE load-bearing test: real server bodies are truncated JSON.
+
+    If the workaround regresses, every call breaks at runtime. Prove the
+    fixture is actually invalid JSON first, then confirm the method still
+    returns the parsed docs array.
+    """
+    # Sanity check: if this fixture ever accidentally becomes valid JSON, the
+    # test no longer exercises the workaround.
+    with pytest.raises(json.JSONDecodeError):
+        json.loads(TRUNCATED_BODY)
+
+    with respx.mock:
+        respx.get("https://test.example.com/_transactor/api/v1/search-fulltext/w-test-123").respond(
+            200, text=TRUNCATED_BODY
+        )
+        async with HulyClient(fake_config, fake_auth) as client:
+            result = await client.fulltext_search("login")
+
+    assert len(result) == 2
+    assert result[0]["id"] == "i1"
+    assert result[0]["doc"]["_class"] == "tracker:class:Issue"
+    assert result[1]["doc"]["_class"] == "document:class:Document"
+
+
+async def test_fulltext_search_query_and_limit_params(fake_config, fake_auth):
+    """fulltext_search sends query + limit as GET query parameters."""
+    with respx.mock:
+        route = respx.get(
+            "https://test.example.com/_transactor/api/v1/search-fulltext/w-test-123"
+        ).respond(200, text='{"docs":[],"total":0')
+        async with HulyClient(fake_config, fake_auth) as client:
+            await client.fulltext_search("project", limit=42)
+        request = route.calls[0].request
+        assert request.url.params["query"] == "project"
+        assert request.url.params["limit"] == "42"
+
+
+async def test_fulltext_search_client_side_class_filter(fake_config, fake_auth):
+    """``classes=`` filters client-side on each doc's nested ``doc._class``."""
+    body = (
+        '{"docs":['
+        '{"id":"i1","title":"Bug","doc":{"_id":"i1","_class":"tracker:class:Issue"},'
+        '"score":10,"iconComponent":"x"},'
+        '{"id":"d1","title":"Doc","doc":{"_id":"d1","_class":"document:class:Document"},'
+        '"score":5,"iconComponent":"x"}'
+        '],"total":1'
+    )
+    with respx.mock:
+        respx.get("https://test.example.com/_transactor/api/v1/search-fulltext/w-test-123").respond(
+            200, text=body
+        )
+        async with HulyClient(fake_config, fake_auth) as client:
+            result = await client.fulltext_search("query", classes=["tracker:class:Issue"])
+    assert len(result) == 1
+    assert result[0]["id"] == "i1"
+
+
+async def test_fulltext_search_empty_docs(fake_config, fake_auth):
+    """An empty ``docs`` array parses cleanly and returns []."""
+    with respx.mock:
+        respx.get("https://test.example.com/_transactor/api/v1/search-fulltext/w-test-123").respond(
+            200, text='{"docs":[],"total":0'
+        )
+        async with HulyClient(fake_config, fake_auth) as client:
+            result = await client.fulltext_search("noresults")
+    assert result == []
+
+
+async def test_fulltext_search_auth_error_on_401(fake_config, fake_auth):
+    with respx.mock:
+        respx.get("https://test.example.com/_transactor/api/v1/search-fulltext/w-test-123").respond(
+            401
+        )
+        async with HulyClient(fake_config, fake_auth) as client:
+            with pytest.raises(AuthError):
+                await client.fulltext_search("q")

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,0 +1,243 @@
+"""Command-layer tests for ``huly search`` and ``huly issues search``.
+
+Uses ``respx`` to mock the fulltext endpoint end-to-end (including a
+truncated-JSON response body), and ``CliRunner`` to exercise the Typer
+command wiring. The truncated-body test is the single most important one in
+this module: if the upstream-workaround regex ever regresses, it re-breaks
+the whole feature.
+"""
+
+from __future__ import annotations
+
+import json
+from contextlib import ExitStack, contextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import respx
+from typer.testing import CliRunner
+
+from huly_cli.config import AuthCache, HulyConfig
+from huly_cli.main import app
+
+runner = CliRunner()
+
+FAKE_CONFIG = HulyConfig(
+    url="https://test.example.com",
+    workspace="test-ws",
+    email="test@test.com",
+    password="testpass",
+)
+
+FAKE_AUTH = AuthCache(
+    account_token="t",
+    workspace_token="t",
+    workspace_id="w",
+    workspace_uuid="u",
+    email="test@test.com",
+    workspace_slug="test",
+    account_id="a",
+    cached_at=1.0,
+)
+
+# A body that intentionally trails off mid-token — mirrors real Huly behavior
+# where Content-Length is declared but the tail is cut at ``"total":N``.
+TRUNCATED_SEARCH_BODY = (
+    '{"docs":['
+    '{"id":"i1","title":"Fix login","doc":'
+    '{"_id":"i1","_class":"tracker:class:Issue"},'
+    '"score":100.5,"iconComponent":"x"},'
+    '{"id":"d1","title":"Onboarding","doc":'
+    '{"_id":"d1","_class":"document:class:Document"},'
+    '"score":42.0,"iconComponent":"x"}'
+    '],"total":1'  # ← no closing ``}``.
+)
+
+
+@contextmanager
+def _auth_patch():
+    """Mock auth + config across every module that uses them directly.
+
+    Patching ``load_config`` is necessary because the search commands go
+    through the real HTTP path (only auth is mocked); without it, the client
+    would build URLs against whatever URL the dev environment resolves.
+    """
+    auth_mock = AsyncMock(return_value=FAKE_AUTH)
+    config_mock = MagicMock(return_value=FAKE_CONFIG)
+    modules = [
+        "huly_cli.auth",
+        "huly_cli.commands.search",
+        "huly_cli.commands.issues",
+    ]
+    with ExitStack() as stack:
+        for module in modules:
+            stack.enter_context(patch(f"{module}.ensure_auth", new=auth_mock))
+        stack.enter_context(patch("huly_cli.commands.search.load_config", config_mock))
+        yield auth_mock
+
+
+# ── Sanity check on the fixture ───────────────────────────────────────────────
+
+
+def test_truncated_fixture_is_actually_invalid_json():
+    """Guard against the fixture silently becoming valid JSON.
+
+    If this assert ever flips, the truncation test below no longer exercises
+    the workaround — it would be testing stock ``json.loads`` on valid input.
+    """
+    import pytest
+
+    with pytest.raises(json.JSONDecodeError):
+        json.loads(TRUNCATED_SEARCH_BODY)
+
+
+# ── huly search ───────────────────────────────────────────────────────────────
+
+
+def test_search_happy_path():
+    """Table output includes class, id, title for each hit."""
+    body = (
+        '{"docs":['
+        '{"id":"i1","title":"Fix login","doc":'
+        '{"_id":"i1","_class":"tracker:class:Issue"},'
+        '"score":100.5,"iconComponent":"x"}'
+        '],"total":1'
+    )
+    with _auth_patch(), respx.mock:
+        respx.get("https://test.example.com/_transactor/api/v1/search-fulltext/w").respond(
+            200, text=body
+        )
+        result = runner.invoke(app, ["search", "login"])
+    assert result.exit_code == 0, result.output
+    assert "Fix login" in result.output
+    assert "tracker:class:Issue" in result.output
+    assert "i1" in result.output
+
+
+def test_search_parses_truncated_response():
+    """THE load-bearing command-layer test: the workaround survives end-to-end."""
+    with _auth_patch(), respx.mock:
+        respx.get("https://test.example.com/_transactor/api/v1/search-fulltext/w").respond(
+            200, text=TRUNCATED_SEARCH_BODY
+        )
+        result = runner.invoke(app, ["search", "anything"])
+    assert result.exit_code == 0, result.output
+    assert "Fix login" in result.output
+    assert "Onboarding" in result.output
+    assert "tracker:class:Issue" in result.output
+    assert "document:class:Document" in result.output
+
+
+def test_search_limit_flag_forwarded_to_server():
+    """``--limit`` shows up as a ``limit=`` query parameter."""
+    with _auth_patch(), respx.mock:
+        route = respx.get("https://test.example.com/_transactor/api/v1/search-fulltext/w").respond(
+            200, text='{"docs":[],"total":0'
+        )
+        result = runner.invoke(app, ["search", "q", "--limit", "7"])
+    assert result.exit_code == 0, result.output
+    assert route.calls[0].request.url.params["limit"] == "7"
+
+
+def test_search_single_class_filter_applied_client_side():
+    """A single ``--class`` restricts the table to just that class."""
+    with _auth_patch(), respx.mock:
+        respx.get("https://test.example.com/_transactor/api/v1/search-fulltext/w").respond(
+            200, text=TRUNCATED_SEARCH_BODY
+        )
+        result = runner.invoke(app, ["search", "q", "--class", "tracker:class:Issue"])
+    assert result.exit_code == 0, result.output
+    assert "Fix login" in result.output
+    # The doc hit must not appear in the output at all.
+    assert "Onboarding" not in result.output
+    assert "document:class:Document" not in result.output
+
+
+def test_search_multiple_class_filters():
+    """Multiple ``--class`` flags union the filter — both classes pass."""
+    with _auth_patch(), respx.mock:
+        respx.get("https://test.example.com/_transactor/api/v1/search-fulltext/w").respond(
+            200, text=TRUNCATED_SEARCH_BODY
+        )
+        result = runner.invoke(
+            app,
+            [
+                "search",
+                "q",
+                "--class",
+                "tracker:class:Issue",
+                "--class",
+                "document:class:Document",
+            ],
+        )
+    assert result.exit_code == 0, result.output
+    assert "Fix login" in result.output
+    assert "Onboarding" in result.output
+
+
+def test_search_json_output_mode():
+    """``--json`` emits a structured envelope with id/class/title/score."""
+    with _auth_patch(), respx.mock:
+        respx.get("https://test.example.com/_transactor/api/v1/search-fulltext/w").respond(
+            200, text=TRUNCATED_SEARCH_BODY
+        )
+        result = runner.invoke(app, ["search", "q", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["ok"] is True
+    assert len(payload["data"]) == 2
+    first = payload["data"][0]
+    assert set(first.keys()) == {"id", "class", "title", "score"}
+    assert first["id"] == "i1"
+    assert first["class"] == "tracker:class:Issue"
+    assert first["score"] == 100.5
+
+
+def test_search_empty_docs_array():
+    """An empty ``docs`` array returns exit 0 with no rows rendered."""
+    with _auth_patch(), respx.mock:
+        respx.get("https://test.example.com/_transactor/api/v1/search-fulltext/w").respond(
+            200, text='{"docs":[],"total":0'
+        )
+        result = runner.invoke(app, ["search", "no-hits"])
+    assert result.exit_code == 0, result.output
+
+
+# ── huly issues search wrapper ───────────────────────────────────────────────
+
+
+def test_issues_search_filters_to_issue_class():
+    """The wrapper prefills the Issue class so non-issue hits drop out."""
+    with _auth_patch(), respx.mock:
+        respx.get("https://test.example.com/_transactor/api/v1/search-fulltext/w").respond(
+            200, text=TRUNCATED_SEARCH_BODY
+        )
+        result = runner.invoke(app, ["issues", "search", "login"])
+    assert result.exit_code == 0, result.output
+    assert "Fix login" in result.output
+    # Document hit must not appear.
+    assert "Onboarding" not in result.output
+
+
+def test_issues_search_parses_truncated_response():
+    """Wrapper must inherit the truncation workaround."""
+    with _auth_patch(), respx.mock:
+        respx.get("https://test.example.com/_transactor/api/v1/search-fulltext/w").respond(
+            200, text=TRUNCATED_SEARCH_BODY
+        )
+        result = runner.invoke(app, ["issues", "search", "login"])
+    assert result.exit_code == 0, result.output
+
+
+def test_issues_search_json_output_mode():
+    """``--json`` on the wrapper emits the same structured envelope."""
+    with _auth_patch(), respx.mock:
+        respx.get("https://test.example.com/_transactor/api/v1/search-fulltext/w").respond(
+            200, text=TRUNCATED_SEARCH_BODY
+        )
+        result = runner.invoke(app, ["issues", "search", "q", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["ok"] is True
+    # Only the issue hit survives.
+    assert len(payload["data"]) == 1
+    assert payload["data"][0]["class"] == "tracker:class:Issue"


### PR DESCRIPTION
## Summary

- Add `huly search "query" [--limit N] [--class CLASS ...] [--json]` — a top-level command that exposes Huly's confirmed-working `/search-fulltext` endpoint, returning ranked, cross-class results from the workspace.
- Add `huly issues search "query" [--limit N] [--json]` — a thin wrapper that pre-fills `--class tracker:class:Issue`. Pairs with #37's `documents search` wrapper; #37 will swap its backend to `/search-fulltext` in a follow-up.
- Implement the upstream JSON-truncation workaround in the client layer (the server ends every response mid-token, so a regex extracts the well-formed `docs` array directly).

## Changes

- `src/huly_cli/client.py` — new `HulyClient.fulltext_search(query, limit, classes)` method. Issues the GET against `/api/v1/search-fulltext/{workspace_id}`, applies the truncation workaround, and filters client-side on each hit's `doc._class` because the server's `&classes=` parameter is not reliable.
- `src/huly_cli/commands/search.py` — new module. Top-level `search` command with default table columns (class, id, title, score) and a `--json` envelope carrying structured `{id, class, title, score}` per hit.
- `src/huly_cli/commands/issues.py` — add `issues search` subcommand that re-uses `_run_search` / `_emit` from `search.py` with `classes=["tracker:class:Issue"]`.
- `src/huly_cli/main.py` — register `search` as a top-level command (matching the `upgrade` pattern, not `add_typer`).
- `tests/test_client.py` — five new async tests for `fulltext_search`, including a load-bearing test that feeds a real-shaped truncated body through `respx` and first asserts the fixture itself raises `JSONDecodeError` (so the test can't silently stop exercising the workaround).
- `tests/test_search.py` — new command-layer test module with 11 `CliRunner` + `respx` tests covering happy path, `--limit`, single `--class`, multiple `--class`, `--json`, empty `docs`, the `issues search` wrapper, and the end-to-end truncation case.
- `README.md` — new `Search` section with examples and caveats, plus a bullet in the features list.
- `skills/huly-cli/SKILL.md` — agent-facing `Fulltext search` section with the client-side class-filter caveat and the truncation-workaround note.

## Test plan

- [x] `uv run pytest -x` — 282 tests pass (including 16 new ones for this feature).
- [x] `uv run ruff format . && uv run ruff check .` — clean.
- [x] `huly --help` lists `search` at the top level alongside `upgrade`.
- [x] `huly search --help` shows the full flag set (`--limit`, `--class` repeatable, `--json`).
- [x] `huly issues search --help` shows the scoped wrapper options.
- [x] Truncation workaround is covered by a dedicated test that first asserts its fixture raises `JSONDecodeError`, guaranteeing the test exercises the regex branch.
- [x] Scope boundary confirmed via `git diff master...HEAD --stat` — only `src/huly_cli/client.py`, `src/huly_cli/commands/search.py` (new), `src/huly_cli/commands/issues.py`, `src/huly_cli/main.py`, `tests/test_client.py`, `tests/test_search.py` (new), `README.md`, `skills/huly-cli/SKILL.md` are touched. `documents.py`, `output.py`, and `markup.py` are untouched.

Closes #41