### PR TITLE
feat: add documents tree command for hierarchical view (#39)

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,13 @@ huly documents describe DOC_ID --set "# Design\n\nContent here."
 huly documents describe DOC_ID --set-file ./doc.md
 huly documents update DOC_ID --title "Updated Title"
 huly documents delete DOC_ID
+
+# Hierarchical view via the parent field
+huly documents tree                             # every space, grouped
+huly documents tree --space "Engineering"       # one teamspace
+huly documents tree --root DOC_ID               # subtree under one doc
+huly documents tree --depth 2                   # cap recursion
+huly --json documents tree                      # nested JSON output
 ```
 
 ### Components

--- a/skills/huly-cli/SKILL.md
+++ b/skills/huly-cli/SKILL.md
@@ -147,7 +147,7 @@ Current implemented command groups:
 - `auth` — login, status
 - `projects` — list, get
 - `issues` — list, get, create, update, delete, describe
-- `documents` — list, get, create, update, delete, describe
+- `documents` — list, get, create, update, delete, describe, tree
 - `components` — list, get, create, update, delete
 - `milestones` — list, get, create, update, delete
 - `templates` — list, get, describe (read/write)
@@ -177,6 +177,15 @@ Issue-specific fields supported on create/update:
 - `--component` — name or ID (use "" to unset on update)
 - `--label` — repeatable flag to attach labels
 - `--description` — markdown text (create only)
+
+Document hierarchy with `documents tree`:
+
+- `huly documents tree` — every space, grouped by teamspace root
+- `huly documents tree --space "Engineering"` — one teamspace
+- `huly documents tree --root DOC_ID` — subtree under one document
+  (takes precedence over `--space`)
+- `--depth N` — cap recursion (1 = direct children only)
+- `huly --json documents tree` — nested `{id, title, children}` JSON
 
 ### 5. Use repo facts when relevant
 

--- a/src/huly_cli/commands/documents.py
+++ b/src/huly_cli/commands/documents.py
@@ -1,4 +1,4 @@
-"""Documents commands: list, get, create, update, describe."""
+"""Documents commands: list, get, create, update, describe, tree."""
 
 from __future__ import annotations
 
@@ -9,6 +9,7 @@ import time
 from typing import Annotated, Any
 
 import typer
+from rich.tree import Tree
 
 from huly_cli.auth import ensure_auth
 from huly_cli.client import HulyClient
@@ -24,6 +25,8 @@ from huly_cli.output import (
     print_success,
     print_warning,
 )
+
+NO_PARENT = "document:ids:NoParent"
 
 app = typer.Typer(help="Manage Huly documents.", no_args_is_help=True)
 
@@ -145,6 +148,227 @@ def docs_list(
         raise typer.Exit(1) from e
 
     print_list(rows, columns=["title", "space", "parent", "id"], title="Documents")
+
+
+# ── tree helpers ─────────────────────────────────────────────────────────────
+
+
+def _normalize_parent(parent: str | None) -> str:
+    """Treat empty string and the sentinel NoParent value as 'no parent'."""
+    if not parent or parent == NO_PARENT:
+        return ""
+    return parent
+
+
+def _build_children_index(docs: list[Document]) -> dict[str, list[Document]]:
+    """Group docs by normalized parent id.
+
+    Orphans (parent points to an ID that isn't in the fetched set) are bucketed
+    under "" (no parent) so they render under their space root instead of
+    vanishing.
+    """
+    ids = {d.id for d in docs}
+    index: dict[str, list[Document]] = {}
+    for doc in docs:
+        parent = _normalize_parent(doc.parent)
+        if parent and parent not in ids:
+            parent = ""  # orphan → attach to synthetic root
+        index.setdefault(parent, []).append(doc)
+    # Sort siblings by rank ascending (same order as Huly UI).
+    for siblings in index.values():
+        siblings.sort(key=lambda d: (d.rank or "", d.title or ""))
+    return index
+
+
+def _doc_to_tree_node(
+    doc: Document,
+    children_index: dict[str, list[Document]],
+    *,
+    remaining: int | None,
+    visited: set[str],
+) -> dict[str, Any]:
+    """Recursively build a {id, title, children: [...]} node.
+
+    ``remaining`` is the number of document levels still allowed starting at
+    this node (``None`` = unlimited). When it reaches ``1`` the current doc is
+    emitted with no children; when ``0`` the node is still emitted but recursion
+    below it stops. Cycles are broken on first re-visit.
+    """
+    node: dict[str, Any] = {"id": doc.id, "title": doc.title, "children": []}
+    if doc.id in visited:
+        return node
+    visited = visited | {doc.id}
+
+    if remaining is not None and remaining <= 1:
+        return node
+
+    next_remaining = None if remaining is None else remaining - 1
+    for child in children_index.get(doc.id, []):
+        node["children"].append(
+            _doc_to_tree_node(
+                child,
+                children_index,
+                remaining=next_remaining,
+                visited=visited,
+            )
+        )
+    return node
+
+
+def _render_tree_node(node: dict[str, Any], parent: Tree) -> None:
+    branch = parent.add(f"{node['title']} [dim]({node['id']})[/dim]")
+    for child in node["children"]:
+        _render_tree_node(child, branch)
+
+
+@app.command("tree")
+def docs_tree(
+    ctx: typer.Context,
+    space: Annotated[
+        str | None,
+        typer.Option("--space", "-s", help="Filter by teamspace name."),
+    ] = None,
+    root: Annotated[
+        str | None,
+        typer.Option("--root", help="Render subtree rooted at this document ID."),
+    ] = None,
+    depth: Annotated[
+        int | None,
+        typer.Option(
+            "--depth",
+            help=(
+                "Cap recursion. Without --root, N = number of document levels "
+                "under each space (1 = top-level docs only). With --root, the "
+                "root itself counts as level 1 (tree -L N semantics)."
+            ),
+        ),
+    ] = None,
+    limit: Annotated[
+        int,
+        typer.Option(
+            "--limit",
+            "-n",
+            help="Maximum number of documents to fetch for building the tree.",
+        ),
+    ] = 1000,
+) -> None:
+    """Render documents hierarchically via the existing parent field.
+
+    Without flags, renders all spaces, grouped by teamspace root. ``--space``
+    narrows to one teamspace; ``--root`` renders a subtree under a single
+    document (takes precedence over ``--space``). ``--depth`` caps recursion.
+    """
+    if depth is not None and depth < 1:
+        print_error("--depth must be >= 1.")
+        raise typer.Exit(1)
+
+    overrides: dict = ctx.obj or {}
+    config = load_config(
+        url_override=overrides.get("url"),
+        workspace_override=overrides.get("workspace"),
+    )
+
+    async def _run() -> tuple[list[dict[str, Any]] | dict[str, Any], bool]:
+        """Return (payload, is_single_root)."""
+        auth = await ensure_auth(config)
+        async with HulyClient(config, auth) as client:
+            space_map = await _fetch_teamspace_map(client)
+
+            query: dict[str, Any] = {}
+            filter_space_id: str | None = None
+            if root is not None:
+                # --root takes precedence; fetch just that document's space.
+                root_doc = await _find_document_by_id(client, root)
+                query["space"] = root_doc.space
+                filter_space_id = root_doc.space
+            elif space:
+                filter_space_id = await _resolve_teamspace_by_name(client, space)
+                query["space"] = filter_space_id
+
+            raw = await client.find_all(
+                "document:class:Document",
+                query=query,
+                options={"limit": limit},
+            )
+            docs = [Document.model_validate(d) for d in raw]
+
+        children_index = _build_children_index(docs)
+
+        if root is not None:
+            # Single subtree rooted at the requested document.
+            root_doc = next((d for d in docs if d.id == root), None)
+            if root_doc is None:
+                raise NotFoundError(f"Document '{root}' not found.")
+            node = _doc_to_tree_node(
+                root_doc,
+                children_index,
+                remaining=depth,
+                visited=set(),
+            )
+            return node, True
+
+        # All-spaces or --space: group by space, each space is a root.
+        if filter_space_id is not None:
+            space_ids = [filter_space_id]
+        else:
+            space_ids = sorted({d.space for d in docs})
+
+        roots: list[dict[str, Any]] = []
+        for sid in space_ids:
+            space_name = space_map.get(sid, sid)
+            space_node: dict[str, Any] = {
+                "id": sid,
+                "title": space_name,
+                "children": [],
+            }
+            top_docs = [d for d in children_index.get("", []) if d.space == sid]
+            for doc in top_docs:
+                space_node["children"].append(
+                    _doc_to_tree_node(
+                        doc,
+                        children_index,
+                        remaining=depth,
+                        visited=set(),
+                    )
+                )
+            roots.append(space_node)
+
+        return roots, False
+
+    try:
+        payload, single_root = asyncio.run(_run())
+    except NotFoundError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+    except AuthError as e:
+        print_error(e.message, hint="Run 'huly auth login' to authenticate.")
+        raise typer.Exit(2) from e
+    except HulyError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+
+    if is_json_mode():
+        envelope: dict[str, Any] = {"ok": True, "data": payload}
+        print(json.dumps(envelope))
+        return
+
+    if single_root:
+        assert isinstance(payload, dict)
+        tree = Tree(f"{payload['title']} [dim]({payload['id']})[/dim]")
+        for child in payload["children"]:
+            _render_tree_node(child, tree)
+        console.print(tree)
+        return
+
+    assert isinstance(payload, list)
+    if not payload:
+        console.print("[dim](no documents)[/dim]")
+        return
+    for space_node in payload:
+        tree = Tree(f"[bold]{space_node['title']}[/bold] [dim]({space_node['id']})[/dim]")
+        for child in space_node["children"]:
+            _render_tree_node(child, tree)
+        console.print(tree)
 
 
 @app.command("get")

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -769,6 +769,216 @@ def test_documents_list_shows_space():
     assert "Engineering" in result.output
 
 
+# ── documents tree ─────────────────────────────────────────────────────────────
+
+
+def _doc(_id, title, parent="document:ids:NoParent", space="ts1", rank=""):
+    return {
+        "_id": _id,
+        "title": title,
+        "content": "",
+        "space": space,
+        "parent": parent,
+        "attachments": 0,
+        "labels": 0,
+        "comments": 0,
+        "rank": rank,
+        "createdBy": "",
+        "createdOn": 0,
+        "modifiedBy": "",
+        "modifiedOn": 0,
+    }
+
+
+TREE_TEAMSPACES = [
+    {
+        "_id": "ts1",
+        "name": "Engineering",
+        "description": "",
+        "private": False,
+        "archived": False,
+        "members": [],
+        "owners": [],
+    },
+    {
+        "_id": "ts2",
+        "name": "Design",
+        "description": "",
+        "private": False,
+        "archived": False,
+        "members": [],
+        "owners": [],
+    },
+]
+
+# A three-level tree in ts1 plus one doc in ts2.
+TREE_DOCS = [
+    _doc("root-a", "Root A", parent="document:ids:NoParent", space="ts1", rank="a"),
+    _doc("root-b", "Root B", parent="document:ids:NoParent", space="ts1", rank="b"),
+    _doc("child-a1", "Child A1", parent="root-a", space="ts1", rank="a"),
+    _doc("child-a2", "Child A2", parent="root-a", space="ts1", rank="b"),
+    _doc("grand-a1a", "Grand A1a", parent="child-a1", space="ts1", rank="a"),
+    _doc("ts2-doc", "Design Doc", parent="document:ids:NoParent", space="ts2"),
+]
+
+
+def test_documents_tree_renders_all_spaces():
+    find_mock = AsyncMock(side_effect=[TREE_TEAMSPACES, TREE_DOCS])
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["documents", "tree"])
+    assert result.exit_code == 0, result.output
+    # Space roots and each doc title appear.
+    assert "Engineering" in result.output
+    assert "Design" in result.output
+    assert "Root A" in result.output
+    assert "Child A1" in result.output
+    assert "Grand A1a" in result.output
+    assert "Design Doc" in result.output
+
+
+def test_documents_tree_filters_by_space():
+    # find_all calls: teamspace map, teamspace resolve, documents.
+    find_mock = AsyncMock(side_effect=[TREE_TEAMSPACES, TREE_TEAMSPACES, TREE_DOCS[:5]])
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["documents", "tree", "--space", "Engineering"])
+    assert result.exit_code == 0, result.output
+    assert "Engineering" in result.output
+    assert "Root A" in result.output
+    # The Design space and its doc should not appear.
+    assert "Design Doc" not in result.output
+
+
+def test_documents_tree_root_subtree():
+    # find_all calls: teamspace map, _find_document_by_id, documents.
+    root_a_rows = [TREE_DOCS[0]]
+    find_mock = AsyncMock(side_effect=[TREE_TEAMSPACES, root_a_rows, TREE_DOCS[:5]])
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["documents", "tree", "--root", "root-a"])
+    assert result.exit_code == 0, result.output
+    assert "Root A" in result.output
+    assert "Child A1" in result.output
+    assert "Grand A1a" in result.output
+    # Sibling root should not appear in a subtree.
+    assert "Root B" not in result.output
+
+
+def test_documents_tree_root_not_found_exits_nonzero():
+    # _find_document_by_id returns [] → NotFoundError.
+    find_mock = AsyncMock(side_effect=[TREE_TEAMSPACES, []])
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["documents", "tree", "--root", "missing-id"])
+    assert result.exit_code == 1
+    assert "missing-id" in result.output or "not found" in result.output.lower()
+
+
+def test_documents_tree_depth_truncates():
+    find_mock = AsyncMock(side_effect=[TREE_TEAMSPACES, TREE_DOCS])
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        # depth=1: only top-level documents under each space.
+        result = runner.invoke(app, ["documents", "tree", "--depth", "1"])
+    assert result.exit_code == 0, result.output
+    assert "Root A" in result.output
+    # Children and grandchildren of Root A should be truncated.
+    assert "Child A1" not in result.output
+    assert "Grand A1a" not in result.output
+
+
+def test_documents_tree_depth_keeps_children_of_direct_children():
+    find_mock = AsyncMock(side_effect=[TREE_TEAMSPACES, TREE_DOCS])
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        # depth=2: top-level docs + their direct children; no grandchildren.
+        result = runner.invoke(app, ["documents", "tree", "--depth", "2"])
+    assert result.exit_code == 0, result.output
+    assert "Root A" in result.output
+    assert "Child A1" in result.output
+    assert "Grand A1a" not in result.output
+
+
+def test_documents_tree_root_depth_counts_root_as_level_1():
+    """With --root, depth=2 shows root + its direct children (tree -L 2)."""
+    root_a_rows = [TREE_DOCS[0]]
+    find_mock = AsyncMock(side_effect=[TREE_TEAMSPACES, root_a_rows, TREE_DOCS[:5]])
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["documents", "tree", "--root", "root-a", "--depth", "2"])
+    assert result.exit_code == 0, result.output
+    assert "Root A" in result.output
+    assert "Child A1" in result.output
+    # Grandchildren truncated at depth=2.
+    assert "Grand A1a" not in result.output
+
+
+def test_documents_tree_json_mode_nested_output():
+    import json as json_mod
+
+    find_mock = AsyncMock(side_effect=[TREE_TEAMSPACES, TREE_DOCS])
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["--json", "documents", "tree"])
+    assert result.exit_code == 0, result.output
+    payload = json_mod.loads(result.output)
+    assert payload["ok"] is True
+    roots = payload["data"]
+    assert isinstance(roots, list)
+    # Space nodes come back in sorted-by-id order; locate by title.
+    eng = next(r for r in roots if r["title"] == "Engineering")
+    # Each node has id/title/children.
+    assert set(eng.keys()) == {"id", "title", "children"}
+    root_a = next(c for c in eng["children"] if c["id"] == "root-a")
+    child_ids = [c["id"] for c in root_a["children"]]
+    assert "child-a1" in child_ids
+    # grandchild reachable
+    child_a1 = next(c for c in root_a["children"] if c["id"] == "child-a1")
+    assert any(g["id"] == "grand-a1a" for g in child_a1["children"])
+
+
+def test_documents_tree_root_json_mode_single_object():
+    import json as json_mod
+
+    root_a_rows = [TREE_DOCS[0]]
+    find_mock = AsyncMock(side_effect=[TREE_TEAMSPACES, root_a_rows, TREE_DOCS[:5]])
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["--json", "documents", "tree", "--root", "root-a"])
+    assert result.exit_code == 0, result.output
+    payload = json_mod.loads(result.output)
+    assert payload["ok"] is True
+    # Single-root mode returns a dict, not a list.
+    assert isinstance(payload["data"], dict)
+    assert payload["data"]["id"] == "root-a"
+    assert payload["data"]["title"] == "Root A"
+
+
+def test_documents_tree_cycle_is_broken():
+    # A↔B cycle: both point at each other; neither is NoParent.
+    cyclic_docs = [
+        _doc("cyc-a", "Cyclic A", parent="cyc-b", space="ts1"),
+        _doc("cyc-b", "Cyclic B", parent="cyc-a", space="ts1"),
+    ]
+    find_mock = AsyncMock(side_effect=[TREE_TEAMSPACES, cyclic_docs])
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["documents", "tree"])
+    # Must not hang or crash; both titles should appear.
+    assert result.exit_code == 0, result.output
+
+
+def test_documents_tree_orphan_renders_under_space_root():
+    # orphan-kid's parent is a doc not in the fetched set → bucket under space root.
+    orphan_docs = [
+        _doc("orphan-kid", "Orphan Kid", parent="missing-parent-id", space="ts1"),
+    ]
+    find_mock = AsyncMock(side_effect=[TREE_TEAMSPACES, orphan_docs])
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["documents", "tree"])
+    assert result.exit_code == 0, result.output
+    assert "Orphan Kid" in result.output
+
+
+def test_documents_tree_invalid_depth_exits_nonzero():
+    # depth=0 is rejected (depth < 1).
+    find_mock = AsyncMock(side_effect=[TREE_TEAMSPACES, TREE_DOCS])
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["documents", "tree", "--depth", "0"])
+    assert result.exit_code == 1
+
+
 # ── components list ────────────────────────────────────────────────────────────
 
 COMPONENT_DATA = [


### PR DESCRIPTION
## Summary

Adds `huly documents tree`, a pure client-side hierarchical renderer over the existing `parent` field on documents. No new RPC — reuses the `find-all` Document query already driving `documents list`.

## Changes

- `src/huly_cli/commands/documents.py` — new `tree` subcommand with `--space`, `--root`, `--depth`, and the global `--json` flag. Helpers `_build_children_index`, `_doc_to_tree_node`, and `_render_tree_node` keep the render logic separate from the async fetch. Orphans (parent pointing at an id outside the fetched set) are bucketed under their space root; cycles are broken on first re-visit via a per-chain `visited` set; siblings are sorted by `rank` so output matches the Huly UI.
- Rich `Tree` renderer for human output; nested `{id, title, children}` objects for JSON. All-spaces / `--space` emits a list of space roots; `--root` emits a single node.
- `--depth` semantics: without `--root`, N = number of document levels under each space (1 = top-level docs only). With `--root`, the root itself counts as level 1 (`tree -L N`). Documented in the help string.
- Default `--limit` is `1000` (tree needs enough nodes to reconstruct the graph); overridable with `-n`.
- `tests/test_commands.py` — 12 new `CliRunner` tests covering: all-spaces, `--space` filter, `--root` subtree, `--root` depth, `--depth` truncation at two levels, `--json` envelope shapes (list for spaces, dict for `--root`), `--root` not-found exit, cycle safety, orphan rendering under space root, `--depth 0` rejection.
- `README.md` — documents tree examples under the Documents section.
- `skills/huly-cli/SKILL.md` — updated command list and added a documents-tree usage block.

## Test plan

- [x] `uv run pytest -x` — 278 passing (12 new)
- [x] `uv run ruff format . && uv run ruff check .` — clean
- [x] `uv run huly documents tree --help` — flags and help strings render correctly
- [x] Scope boundary: only `src/huly_cli/commands/documents.py`, `tests/test_commands.py`, `README.md`, `skills/huly-cli/SKILL.md` modified; `client.py` and `output.py` untouched

Closes #39