### PR TITLE
feat: stop truncating IDs in tables and add --markdown to documents describe (#38)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ Additional capabilities:
 - **Status filtering**: `issues list --status <name>` resolves against the live
   workspace status index, supporting custom statuses
 - **JSON mode**: `huly --json <command>` for machine-readable output
+- **Full IDs in tables**: `id` and `parent` columns in list output never
+  truncate to `…` — values are always copy-pasteable into subsequent commands
+- **Agent-friendly markdown**: `huly documents describe DOC_ID --markdown`
+  emits plain GFM with no Rich box or reflow
 - **Self-upgrade**: `huly upgrade` to update from PyPI
 - **Shell completion**: `huly --install-completion`
 
@@ -185,11 +189,23 @@ huly issues delete DEMO-1
 ```bash
 huly documents list --space "Engineering"
 huly documents create --space "Engineering" --title "Design Doc"
+
+# Read content
+huly documents describe DOC_ID              # rendered markdown in a Rich panel
+huly documents describe DOC_ID --markdown   # plain GFM to stdout — safe to pipe, diff, or feed back into --set-file
+huly documents describe DOC_ID --raw        # raw ProseMirror JSON
+
+# Write content
 huly documents describe DOC_ID --set "# Design\n\nContent here."
 huly documents describe DOC_ID --set-file ./doc.md
+
 huly documents update DOC_ID --title "Updated Title"
 huly documents delete DOC_ID
 ```
+
+`--markdown` is the preferred read path for agents: no Rich box, no reflow, no
+ellipsis truncation, and the output round-trips cleanly back into `--set-file`.
+`--raw` and `--markdown` are mutually exclusive.
 
 ### Components
 

--- a/skills/huly-cli/SKILL.md
+++ b/skills/huly-cli/SKILL.md
@@ -142,6 +142,22 @@ components, and milestones.
 
 Prefer `--json` when an agent needs stable machine-readable output.
 
+Agent-friendly read paths for document content:
+
+- `huly documents describe DOC_ID --markdown` — plain GFM to stdout, no Rich
+  box and no reflow. Preferred over the default rendered output when the agent
+  will diff, grep, or re-emit the content. Also safe to pipe into
+  `--set-file` for round-trips.
+- `huly documents describe DOC_ID --raw` — raw ProseMirror JSON (structural,
+  not line-diffable).
+- `huly documents describe DOC_ID` (no flag) — rendered Rich panel, for humans.
+
+`--raw` and `--markdown` are mutually exclusive.
+
+ID columns in list output (`huly documents list`, `huly components list`, etc.)
+always show the full ID — agents can copy values directly into follow-up
+`huly ... get <ID>` calls without re-querying with `--json`.
+
 Current implemented command groups:
 
 - `auth` — login, status

--- a/src/huly_cli/commands/documents.py
+++ b/src/huly_cli/commands/documents.py
@@ -300,6 +300,13 @@ def docs_describe(
         bool,
         typer.Option("--raw", help="Show raw ProseMirror JSON instead of rendered markdown."),
     ] = False,
+    markdown: Annotated[
+        bool,
+        typer.Option(
+            "--markdown",
+            help="Emit plain GFM markdown to stdout (no Rich box/reflow) — agent-friendly.",
+        ),
+    ] = False,
     set_text: Annotated[
         str | None,
         typer.Option("--set", help="Set content from markdown string."),
@@ -312,9 +319,14 @@ def docs_describe(
     """Read or update the content of a document.
 
     By default, reads and displays the content. Use --set or --set-file to write.
+    Use --markdown to emit plain GFM (no Rich panel), which is safe to diff,
+    grep, or feed back into `--set-file`.
     """
     if set_text is not None and set_file is not None:
         print_error("Use either --set or --set-file, not both.")
+        raise typer.Exit(1)
+    if raw and markdown:
+        print_error("Use either --raw or --markdown, not both.")
         raise typer.Exit(1)
 
     overrides: dict = ctx.obj or {}
@@ -433,6 +445,13 @@ def docs_describe(
             console.print_json(json.dumps(parsed, indent=2))
         except (json.JSONDecodeError, TypeError):
             console.print(content)
+    elif markdown:
+        # Plain GFM to stdout — no Rich box, no reflow. Agent-friendly and safe
+        # to round-trip back through `--set` / `--set-file`.
+        from huly_cli.markup import prosemirror_to_markdown
+
+        md_text = prosemirror_to_markdown(content)
+        print(md_text)
     else:
         from rich.markdown import Markdown
         from rich.panel import Panel

--- a/src/huly_cli/output.py
+++ b/src/huly_cli/output.py
@@ -41,14 +41,30 @@ def print_item(data: dict[str, Any], title: str = "") -> None:
             console.print(Pretty(data))
 
 
+#: Columns whose values are IDs/refs that must never be truncated with an
+#: ellipsis — a truncated ID is useless (you can't use it to look the row up).
+#: Rich's default `overflow="ellipsis"` produces e.g. `69cba04d0122c97…`; we
+#: set `no_wrap=True` so Rich widens the column to fit the full ID on one line
+#: (other columns wrap to absorb any squeeze on narrow terminals).
+_NO_TRUNCATE_COLUMNS: frozenset[str] = frozenset({"id", "parent"})
+
+
 def print_list(items: list[dict[str, Any]], columns: list[str], title: str = "") -> None:
-    """Print a list of items. JSON: envelope with data array. Human: Rich table."""
+    """Print a list of items. JSON: envelope with data array. Human: Rich table.
+
+    Columns named ``id`` or ``parent`` render without Rich's ellipsis
+    truncation — full values always appear so they can be copied and reused
+    (a truncated Huly ID is not a valid lookup key).
+    """
     if _json_mode:
         print(json.dumps({"ok": True, "data": items}))
     else:
         table = Table(title=title or None, show_header=True, header_style="bold")
         for col in columns:
-            table.add_column(col)
+            if col in _NO_TRUNCATE_COLUMNS:
+                table.add_column(col, no_wrap=True, overflow="fold")
+            else:
+                table.add_column(col)
         for item in items:
             row = [str(item.get(col, "")) for col in columns]
             table.add_row(*row)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1151,3 +1151,182 @@ def test_components_update_not_found_exits_nonzero():
 
     assert result.exit_code == 1
     tx_mock.assert_not_awaited()
+
+
+# ── ID column truncation (issue #38) ──────────────────────────────────────────
+#
+# A truncated Huly ID is useless: `huly documents get 69cba04d0122c97…` returns
+# "not found". The tests below are snapshot-ish guards that regress if Rich's
+# default ellipsis overflow sneaks back in for ID / parent columns.
+
+LONG_DOC_ID = "69cba08c0122c97fabcdef34"
+LONG_PARENT_ID = "69cba04d0122c97fabcdef12"
+
+LONG_ID_DOCUMENT_DATA = [
+    {
+        "_id": LONG_DOC_ID,
+        "title": "[Template] Weekly Project Status",
+        "content": "blob-ref-123",
+        "space": "ts1",
+        "parent": LONG_PARENT_ID,
+        "attachments": 0,
+        "labels": 0,
+        "comments": 0,
+        "rank": "",
+        "createdBy": "",
+        "createdOn": 0,
+        "modifiedBy": "",
+        "modifiedOn": 0,
+    }
+]
+
+
+def test_documents_list_shows_full_id_no_ellipsis():
+    """ID column must render the full 24-char ID; `…` truncation is a regression."""
+    find_mock = AsyncMock(side_effect=[TEAMSPACE_DATA, LONG_ID_DOCUMENT_DATA])
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["documents", "list"])
+    assert result.exit_code == 0, result.output
+    # The full ID must be present exactly — not truncated to e.g. `69cba08c0122c97f…`.
+    assert LONG_DOC_ID in result.output
+    # A truncated prefix + ellipsis is the bug from issue #38. Assert neither
+    # the Unicode nor the ASCII truncation marker ever appears in the ID.
+    assert "…" not in result.output
+    assert "0122c97..." not in result.output
+
+
+def test_documents_list_shows_full_parent_id_no_ellipsis():
+    """`parent` is also an ID — it must not be truncated either."""
+    find_mock = AsyncMock(side_effect=[TEAMSPACE_DATA, LONG_ID_DOCUMENT_DATA])
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["documents", "list"])
+    assert result.exit_code == 0, result.output
+    assert LONG_PARENT_ID in result.output
+
+
+def test_issues_list_still_renders_identifier_after_truncation_fix():
+    """Sanity: the no-truncate change in print_list must not break other tables.
+
+    `issues list` has no `id` column, but it has `identifier` (e.g. TP-1) and
+    other columns that still wrap/truncate normally.
+    """
+    find_mock = AsyncMock(side_effect=[ISSUE_DATA, []])
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["issues", "list"])
+    assert result.exit_code == 0, result.output
+    # Full issue identifier must be intact (it's short, but this pins the
+    # behaviour so future refactors of print_list can't silently swallow it).
+    assert "TP-1" in result.output
+    assert "TP-1…" not in result.output
+
+
+def test_components_list_shows_full_id_no_ellipsis():
+    """Components list `id` column must also render the full 24-char ID."""
+    long_id = "69cba0aa0122c97fcomponent"
+    component_data = [
+        {
+            "_id": long_id,
+            "label": "Auth Service",
+            "description": "Handles auth",
+            "lead": None,
+            "space": "proj1",
+            "createdBy": "",
+            "createdOn": 0,
+            "modifiedBy": "",
+            "modifiedOn": 0,
+        }
+    ]
+    find_mock = AsyncMock(side_effect=[component_data, []])
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["components", "list"])
+    assert result.exit_code == 0, result.output
+    assert long_id in result.output
+    assert "…" not in result.output
+
+
+# ── documents describe --markdown (issue #38) ────────────────────────────────
+#
+# `--raw` dumps ProseMirror JSON; the default renders through a Rich panel that
+# reflows tables. `--markdown` must emit plain GFM to stdout with no box chars.
+
+PROSE_CONTENT = (
+    '{"type":"doc","content":['
+    '{"type":"heading","attrs":{"level":1},"content":[{"type":"text","text":"Hello"}]},'
+    '{"type":"paragraph","content":[{"type":"text","text":"Body text."}]}'
+    "]}"
+)
+
+DOCUMENT_WITH_INLINE_CONTENT = [
+    {
+        "_id": "doc1",
+        "title": "My Doc",
+        "content": PROSE_CONTENT,  # starts with `{` → treated as inline markup, no blob fetch
+        "space": "ts1",
+        "parent": "document:ids:NoParent",
+        "attachments": 0,
+        "labels": 0,
+        "comments": 0,
+        "rank": "",
+        "createdBy": "",
+        "createdOn": 0,
+        "modifiedBy": "",
+        "modifiedOn": 0,
+    }
+]
+
+
+def test_documents_describe_markdown_emits_plain_gfm():
+    """`documents describe --markdown` writes plain GFM to stdout (no Rich box)."""
+    from huly_cli.output import set_json_mode
+
+    set_json_mode(False)  # isolate from any prior `--json` test leaking state.
+    find_mock = AsyncMock(return_value=DOCUMENT_WITH_INLINE_CONTENT)
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["documents", "describe", "doc1", "--markdown"])
+    assert result.exit_code == 0, result.output
+    # Markdown heading / body must be present.
+    assert "# Hello" in result.output
+    assert "Body text." in result.output
+    # No Rich panel borders (heavy box or rounded) — those would indicate the
+    # old Panel/Markdown path leaked through.
+    for box_char in ("╭", "╮", "╰", "╯", "┏", "┓", "┗", "┛", "━"):
+        assert box_char not in result.output, (
+            f"Rich box char {box_char!r} leaked into --markdown output"
+        )
+    # No panel title wrapper like `Content: My Doc`.
+    assert "Content: My Doc" not in result.output
+
+
+def test_documents_describe_markdown_conflicts_with_raw():
+    """`--raw` and `--markdown` are mutually exclusive — mirrors the existing
+    `--set` / `--set-file` mutual-exclusion check in the same command."""
+    result = runner.invoke(app, ["documents", "describe", "doc1", "--raw", "--markdown"])
+    assert result.exit_code == 1
+    # Error message should make the exclusivity clear.
+    assert "either" in result.output.lower() or "not both" in result.output.lower()
+
+
+def test_documents_describe_default_still_renders_panel():
+    """Default (no --markdown, no --raw) keeps the Rich panel rendering."""
+    from huly_cli.output import set_json_mode
+
+    set_json_mode(False)  # isolate from any prior `--json` test leaking state.
+    find_mock = AsyncMock(return_value=DOCUMENT_WITH_INLINE_CONTENT)
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["documents", "describe", "doc1"])
+    assert result.exit_code == 0, result.output
+    # Panel title appears in the default human rendering.
+    assert "Content:" in result.output
+
+
+def test_documents_describe_markdown_json_mode_still_emits_envelope():
+    """In JSON mode, --markdown is redundant; output stays a JSON envelope."""
+    import json as json_mod
+
+    find_mock = AsyncMock(return_value=DOCUMENT_WITH_INLINE_CONTENT)
+    with _auth_patch(), patch("huly_cli.client.HulyClient.find_all", find_mock):
+        result = runner.invoke(app, ["--json", "documents", "describe", "doc1", "--markdown"])
+    assert result.exit_code == 0, result.output
+    data = json_mod.loads(result.output)
+    assert data["ok"] is True
+    assert "# Hello" in data["content"]

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -153,3 +153,57 @@ class TestPrintErrorJson:
         # Should be on stderr, not stdout
         assert captured.out == ""
         assert captured.err != ""
+
+
+class TestPrintListIdTruncation:
+    """Regression tests for issue #38: ID columns must never render with `…`.
+
+    Rich's default `overflow="ellipsis"` truncates 24-char hex Huly IDs to
+    something like `69cba04d0122c97…`, which users then copy into `huly
+    documents get …` only to hit "not found". `print_list` widens `id` and
+    `parent` columns so the full value always appears and can be reused.
+    """
+
+    def setup_method(self):
+        set_json_mode(False)
+
+    def teardown_method(self):
+        set_json_mode(False)
+
+    def test_id_column_shows_full_value(self, capsys):
+        from huly_cli.output import print_list
+
+        long_id = "69cba08c0122c97fabcdef34"
+        print_list([{"title": "Doc", "id": long_id}], columns=["title", "id"])
+        captured = capsys.readouterr()
+        assert long_id in captured.out
+        assert "…" not in captured.out
+
+    def test_parent_column_shows_full_value(self, capsys):
+        from huly_cli.output import print_list
+
+        long_parent = "69cba04d0122c97fabcdef12"
+        print_list(
+            [{"title": "Doc", "parent": long_parent, "id": "x"}],
+            columns=["title", "parent", "id"],
+        )
+        captured = capsys.readouterr()
+        assert long_parent in captured.out
+        assert "…" not in captured.out
+
+    def test_non_id_columns_still_allowed_to_truncate(self, capsys):
+        """Only `id` / `parent` are protected; other long columns may still wrap/truncate.
+
+        We don't strictly assert truncation (Rich's terminal-width detection in
+        a non-tty may widen the table anyway); the point is that the helper
+        doesn't crash or mis-render non-ID columns when the ID rule triggers.
+        """
+        from huly_cli.output import print_list
+
+        print_list(
+            [{"title": "x" * 80, "id": "69cba08c0122c97fabcdef34"}],
+            columns=["title", "id"],
+        )
+        captured = capsys.readouterr()
+        # Full ID still present; no crash.
+        assert "69cba08c0122c97fabcdef34" in captured.out


### PR DESCRIPTION
## Summary

Two surgical output-layer fixes. Neither touches CRUD logic.

- `huly documents list`, `huly components list`, etc. no longer render the `id` / `parent` columns with Rich's ellipsis truncation, so copying an ID out of a terminal actually works.
- `huly documents describe --markdown` emits plain GFM to stdout — no Rich box, no reflow — so agents can diff, grep, and round-trip content back through `--set-file`.

## Changes

- `src/huly_cli/output.py` — `print_list` now opts columns named `id` / `parent` out of default ellipsis overflow (`no_wrap=True, overflow="fold"`). Rule is centralized in the helper; no per-command plumbing.
- `src/huly_cli/commands/documents.py` — `docs_describe` gains `--markdown` (human-only flag; JSON mode already returns markdown by default). Mutually exclusive with `--raw`, following the same pattern as the existing `--set` / `--set-file` check.
- `tests/test_commands.py` — CliRunner tests:
  - `documents list` renders the full 24-char ID with no `…`
  - `parent` column also shows the full ID
  - `components list` same
  - `issues list` still renders short identifiers intact after the helper change
  - `documents describe --markdown` produces plain GFM with no Rich box chars (`╭╮╰╯┏┓┗┛━`) and no panel title
  - `--raw` + `--markdown` → exit 1 with a clear error
  - default rendering still uses the Rich panel
  - JSON mode + `--markdown` still emits the JSON envelope
- `tests/test_output.py` — helper-level snapshot-ish guards on `print_list` so the no-truncate rule cannot silently regress.
- `README.md` — documents the `--markdown` flag and the full-ID behavior.
- `skills/huly-cli/SKILL.md` — agent-facing guidance that `describe --markdown` is the preferred read path.

## Test plan

- [x] `uv run pytest -x` — 277 passed
- [x] `uv run ruff format . && uv run ruff check .` — clean
- [x] Manual smoke: `uv run huly documents describe --help` shows `--markdown`
- [x] Manual smoke: rendering a real `print_list` with 24-char IDs shows them in full
- [x] Scope check: `git diff master --stat` touches only `src/huly_cli/output.py`, `src/huly_cli/commands/documents.py`, the two test files, `README.md`, and `skills/huly-cli/SKILL.md`

Closes #38