### PR TITLE
feat: add documents duplicate command for template instantiation (#40)

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,8 +188,13 @@ huly documents create --space "Engineering" --title "Design Doc"
 huly documents describe DOC_ID --set "# Design\n\nContent here."
 huly documents describe DOC_ID --set-file ./doc.md
 huly documents update DOC_ID --title "Updated Title"
+huly documents duplicate DOC_ID --title "Weekly Status — 2026-04-19"
 huly documents delete DOC_ID
 ```
+
+`documents duplicate` copies a source document into a new one in a single
+command — useful for instantiating template-style docs. It inherits the
+source's space and parent by default; pass `--space` or `--parent` to override.
 
 ### Components
 

--- a/skills/huly-cli/SKILL.md
+++ b/skills/huly-cli/SKILL.md
@@ -147,7 +147,7 @@ Current implemented command groups:
 - `auth` — login, status
 - `projects` — list, get
 - `issues` — list, get, create, update, delete, describe
-- `documents` — list, get, create, update, delete, describe
+- `documents` — list, get, create, update, delete, describe, duplicate
 - `components` — list, get, create, update, delete
 - `milestones` — list, get, create, update, delete
 - `templates` — list, get, describe (read/write)
@@ -177,6 +177,19 @@ Issue-specific fields supported on create/update:
 - `--component` — name or ID (use "" to unset on update)
 - `--label` — repeatable flag to attach labels
 - `--description` — markdown text (create only)
+
+Common agent workflow — clone a weekly template:
+
+```bash
+# User: "make me a copy of the RAG template for this week"
+huly documents duplicate TEMPLATE_DOC_ID \
+  --title "Weekly Project Status Report (RAG) — 2026-04-19"
+# → prints the new document ID; with --json returns the full record
+```
+
+`documents duplicate` inherits the source document's space and parent by
+default and copies its markdown content into the new doc in one call. Pass
+`--space "Name"` or `--parent DOC_ID` to override those defaults.
 
 ### 5. Use repo facts when relevant
 

--- a/src/huly_cli/commands/documents.py
+++ b/src/huly_cli/commands/documents.py
@@ -94,6 +94,70 @@ async def _find_document_by_id(client: HulyClient, doc_id: str) -> Document:
     return Document.model_validate(raw[0])
 
 
+async def _read_doc_markdown(client: HulyClient, doc: Document) -> str:
+    """Read a document's content and return it as markdown.
+
+    Mirrors the non-raw read path used by ``documents describe``:
+    honors the inline-vs-blob branch and falls through to an empty string
+    when the doc has no content.
+    """
+    from huly_cli.markup import prosemirror_to_markdown
+
+    if not doc.content:
+        return ""
+    if _is_inline_markup(doc.content):
+        content = doc.content
+    else:
+        content = await client.get_content(
+            "document:class:Document", doc.id, "content", doc.content
+        )
+    if not content:
+        return ""
+    return prosemirror_to_markdown(content)
+
+
+async def _write_markdown_to_doc(
+    client: HulyClient, auth: Any, doc: Document, markdown_content: str
+) -> None:
+    """Write markdown content to an existing document.
+
+    Mirrors the write path used by ``documents describe --set-file``:
+    uses ``set_content`` when a blob ref already exists, otherwise
+    calls ``create_content`` then patches the ``content`` field via tx.
+    """
+    from huly_cli.markup import markdown_to_prosemirror
+
+    markup = markdown_to_prosemirror(markdown_content or "")
+    if doc.content and not _is_inline_markup(doc.content):
+        ok = await client.set_content(
+            "document:class:Document", doc.id, "content", doc.content, markup
+        )
+        if not ok:
+            raise HulyError("Failed to update content via Collaborator RPC.")
+        return
+
+    blob_ref = await client.create_content(
+        "document:class:Document",
+        doc.id,
+        "content",
+        markup,
+        warn_on_error=False,
+    )
+    if blob_ref is None:
+        raise HulyError("Failed to create content via Collaborator.")
+    await client.tx(
+        {
+            "_class": "core:class:TxUpdateDoc",
+            "objectClass": "document:class:Document",
+            "objectSpace": doc.space,
+            "objectId": doc.id,
+            "operations": {"content": blob_ref},
+            "modifiedBy": auth.account_id,
+            "modifiedOn": int(time.time() * 1000),
+        }
+    )
+
+
 # ── Commands ──────────────────────────────────────────────────────────────────
 
 
@@ -336,39 +400,10 @@ def docs_describe(
             markdown_content = p.read_text(encoding="utf-8")
 
         async def _write() -> str:
-            from huly_cli.markup import markdown_to_prosemirror
-
             auth = await ensure_auth(config)
             async with HulyClient(config, auth) as client:
-                markup = markdown_to_prosemirror(markdown_content or "")
                 doc = await _find_document_by_id(client, doc_id)
-                if doc.content and not _is_inline_markup(doc.content):
-                    ok = await client.set_content(
-                        "document:class:Document", doc.id, "content", doc.content, markup
-                    )
-                    if not ok:
-                        raise HulyError("Failed to update content via Collaborator RPC.")
-                else:
-                    blob_ref = await client.create_content(
-                        "document:class:Document",
-                        doc.id,
-                        "content",
-                        markup,
-                        warn_on_error=False,
-                    )
-                    if blob_ref is None:
-                        raise HulyError("Failed to create content via Collaborator.")
-                    await client.tx(
-                        {
-                            "_class": "core:class:TxUpdateDoc",
-                            "objectClass": "document:class:Document",
-                            "objectSpace": doc.space,
-                            "objectId": doc.id,
-                            "operations": {"content": blob_ref},
-                            "modifiedBy": auth.account_id,
-                            "modifiedOn": int(time.time() * 1000),
-                        }
-                    )
+                await _write_markdown_to_doc(client, auth, doc, markdown_content or "")
             return doc.title or doc_id
 
         try:
@@ -447,6 +482,107 @@ def docs_describe(
 
             plain = prosemirror_to_text(content)
             console.print(Panel(plain or "(empty content)", title=f"Content: {title_label}"))
+
+
+@app.command("duplicate")
+def docs_duplicate(
+    ctx: typer.Context,
+    doc_id: str = typer.Argument(..., help="Source document internal ID."),
+    title: Annotated[str, typer.Option("--title", help="Title for the new document.")] = ...,
+    space: Annotated[
+        str | None,
+        typer.Option("--space", help="Teamspace name. Defaults to the source's space."),
+    ] = None,
+    parent: Annotated[
+        str | None,
+        typer.Option(
+            "--parent",
+            help="Parent document ID. Defaults to the source's parent.",
+        ),
+    ] = None,
+) -> None:
+    """Duplicate a document, copying its content into a new document.
+
+    Reads the source document's metadata and markdown content, creates a new
+    document in the target (or inherited) space/parent, and writes the content
+    into it. Prints the new document ID; with ``--json`` returns the full record.
+    """
+    overrides: dict = ctx.obj or {}
+    config = load_config(
+        url_override=overrides.get("url"),
+        workspace_override=overrides.get("workspace"),
+    )
+
+    async def _run() -> dict[str, Any]:
+        auth = await ensure_auth(config)
+        async with HulyClient(config, auth) as client:
+            source = await _find_document_by_id(client, doc_id)
+
+            # Resolve target space: inherit source when --space not given.
+            if space is None:
+                target_space_id = source.space
+            else:
+                target_space_id = await _resolve_teamspace_by_name(client, space)
+
+            # Resolve target parent: inherit source when --parent not given.
+            target_parent_id = parent if parent is not None else source.parent
+            if not target_parent_id:
+                target_parent_id = "document:ids:NoParent"
+
+            # Read source content as markdown (same path as describe non-raw).
+            markdown_content = await _read_doc_markdown(client, source)
+
+            # Create the new doc shell.
+            new_id = secrets.token_hex(12)
+            await client.tx(
+                {
+                    "_class": "core:class:TxCreateDoc",
+                    "objectClass": "document:class:Document",
+                    "objectSpace": target_space_id,
+                    "objectId": new_id,
+                    "attributes": {
+                        "title": title,
+                        "content": "",
+                        "parent": target_parent_id,
+                        "attachments": 0,
+                        "embeddings": 0,
+                        "labels": 0,
+                        "comments": 0,
+                        "references": 0,
+                        "rank": "",
+                    },
+                    "modifiedBy": auth.account_id,
+                    "modifiedOn": int(time.time() * 1000),
+                }
+            )
+
+            # Copy content into the new doc (same path as --set-file).
+            if markdown_content:
+                new_doc = await _find_document_by_id(client, new_id)
+                await _write_markdown_to_doc(client, auth, new_doc, markdown_content)
+
+            if is_json_mode():
+                new_doc = await _find_document_by_id(client, new_id)
+                space_map = await _fetch_teamspace_map(client)
+                return _doc_to_detail(new_doc, space_map)
+            return {"id": new_id}
+
+    try:
+        data = asyncio.run(_run())
+    except NotFoundError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+    except AuthError as e:
+        print_error(e.message, hint="Run 'huly auth login' to authenticate.")
+        raise typer.Exit(2) from e
+    except HulyError as e:
+        print_error(e.message)
+        raise typer.Exit(1) from e
+
+    if is_json_mode():
+        print_item(data, title=f"Document: {data.get('title', data.get('id', ''))}")
+    else:
+        print_success(f"Document duplicated (id: {data['id']})")
 
 
 @app.command("delete")

--- a/tests/test_issue_write_path.py
+++ b/tests/test_issue_write_path.py
@@ -773,3 +773,296 @@ def test_templates_describe_rejects_set_and_set_file(tmp_path):
 
     assert result.exit_code != 0, result.output
     assert "Use either --set or --set-file, not both." in result.output
+
+
+# ── documents duplicate (#40) ─────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _reset_json_mode():
+    """Reset the module-level JSON mode flag between tests.
+
+    CLI tests without ``--json`` otherwise inherit JSON mode from any prior
+    test that set it (module-level state in ``huly_cli.output``).
+    """
+    from huly_cli.output import set_json_mode
+
+    set_json_mode(False)
+    yield
+    set_json_mode(False)
+
+
+def _raw_document(**overrides: object) -> dict[str, object]:
+    doc: dict[str, object] = {
+        "_id": "doc-src",
+        "title": "Weekly Template",
+        "content": "blob-src-1",
+        "space": "ts-src",
+        "parent": "document:ids:NoParent",
+        "attachments": 0,
+        "labels": 0,
+        "comments": 0,
+        "rank": "",
+        "createdBy": "",
+        "createdOn": 0,
+        "modifiedBy": "",
+        "modifiedOn": 0,
+    }
+    doc.update(overrides)
+    return doc
+
+
+_INLINE_MARKUP = (
+    '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"hi"}]}]}'
+)
+
+
+def test_documents_duplicate_inherits_space_and_parent(fake_auth):
+    """duplicate without --space/--parent inherits source's space and parent."""
+    source = _raw_document(content=_INLINE_MARKUP, parent="doc-parent-src")
+    new_empty = _raw_document(
+        _id="doc-new",
+        title="Copy",
+        content="",
+        space="ts-src",
+        parent="doc-parent-src",
+    )
+
+    find_all_mock = AsyncMock(side_effect=[[source], [new_empty]])
+    tx_mock = AsyncMock(return_value={})
+    create_content_mock = AsyncMock(return_value="blob-new-1")
+
+    with (
+        patch("huly_cli.commands.documents.ensure_auth", new=AsyncMock(return_value=fake_auth)),
+        patch("huly_cli.client.HulyClient.find_all", find_all_mock),
+        patch("huly_cli.client.HulyClient.tx", tx_mock),
+        patch("huly_cli.client.HulyClient.create_content", create_content_mock),
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "documents",
+                "duplicate",
+                "doc-src",
+                "--title",
+                "Copy",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "Document duplicated" in result.output
+
+    # The create tx should target the source's space + parent.
+    create_tx = tx_mock.await_args_list[0].args[0]
+    assert create_tx["_class"] == "core:class:TxCreateDoc"
+    assert create_tx["objectClass"] == "document:class:Document"
+    assert create_tx["objectSpace"] == "ts-src"
+    assert create_tx["attributes"]["title"] == "Copy"
+    assert create_tx["attributes"]["parent"] == "doc-parent-src"
+
+    # The content-update tx should patch the new doc's content with the blob ref.
+    content_tx = tx_mock.await_args_list[1].args[0]
+    assert content_tx["_class"] == "core:class:TxUpdateDoc"
+    assert content_tx["objectSpace"] == "ts-src"
+    assert content_tx["operations"] == {"content": "blob-new-1"}
+
+    create_content_mock.assert_awaited_once()
+
+
+def test_documents_duplicate_overrides_space(fake_auth):
+    """duplicate --space NAME resolves NAME to a teamspace id for the new doc."""
+    source = _raw_document(content=_INLINE_MARKUP)
+    target_ts = {
+        "_id": "ts-target",
+        "name": "Ops",
+        "description": "",
+        "private": False,
+        "archived": False,
+        "members": [],
+        "owners": [],
+    }
+    new_empty = _raw_document(_id="doc-new", content="", space="ts-target")
+
+    find_all_mock = AsyncMock(
+        side_effect=[
+            [source],  # _find_document_by_id(source)
+            [target_ts],  # _resolve_teamspace_by_name("Ops")
+            [new_empty],  # _find_document_by_id(new) for write
+        ]
+    )
+    tx_mock = AsyncMock(return_value={})
+    create_content_mock = AsyncMock(return_value="blob-new-2")
+
+    with (
+        patch("huly_cli.commands.documents.ensure_auth", new=AsyncMock(return_value=fake_auth)),
+        patch("huly_cli.client.HulyClient.find_all", find_all_mock),
+        patch("huly_cli.client.HulyClient.tx", tx_mock),
+        patch("huly_cli.client.HulyClient.create_content", create_content_mock),
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "documents",
+                "duplicate",
+                "doc-src",
+                "--title",
+                "Copy in Ops",
+                "--space",
+                "Ops",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    create_tx = tx_mock.await_args_list[0].args[0]
+    assert create_tx["objectSpace"] == "ts-target"
+    assert create_tx["attributes"]["title"] == "Copy in Ops"
+
+
+def test_documents_duplicate_overrides_parent(fake_auth):
+    """duplicate --parent DOC_ID places the new doc under the given parent."""
+    source = _raw_document(content=_INLINE_MARKUP, parent="doc-parent-src")
+    new_empty = _raw_document(_id="doc-new", content="", parent="doc-parent-override")
+
+    find_all_mock = AsyncMock(side_effect=[[source], [new_empty]])
+    tx_mock = AsyncMock(return_value={})
+    create_content_mock = AsyncMock(return_value="blob-new-3")
+
+    with (
+        patch("huly_cli.commands.documents.ensure_auth", new=AsyncMock(return_value=fake_auth)),
+        patch("huly_cli.client.HulyClient.find_all", find_all_mock),
+        patch("huly_cli.client.HulyClient.tx", tx_mock),
+        patch("huly_cli.client.HulyClient.create_content", create_content_mock),
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "documents",
+                "duplicate",
+                "doc-src",
+                "--title",
+                "Copy",
+                "--parent",
+                "doc-parent-override",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    create_tx = tx_mock.await_args_list[0].args[0]
+    assert create_tx["attributes"]["parent"] == "doc-parent-override"
+    # Space still inherited from source.
+    assert create_tx["objectSpace"] == "ts-src"
+
+
+def test_documents_duplicate_json_returns_full_record(fake_auth):
+    """--json returns the full new record including the generated id."""
+    from huly_cli.output import set_json_mode
+
+    source = _raw_document(content=_INLINE_MARKUP)
+    teamspace = {
+        "_id": "ts-src",
+        "name": "Engineering",
+        "description": "",
+        "private": False,
+        "archived": False,
+        "members": [],
+        "owners": [],
+    }
+
+    # side_effect for find_all, in order:
+    #  1. source lookup
+    #  2. new-doc re-fetch (write path)
+    #  3. new-doc re-fetch (JSON detail)
+    #  4. teamspace map (JSON detail)
+    def new_doc_with_blob():
+        return _raw_document(_id="doc-new", content="blob-new-4", title="Copy")
+
+    find_all_mock = AsyncMock(
+        side_effect=[
+            [source],
+            [_raw_document(_id="doc-new", content="", title="Copy")],
+            [new_doc_with_blob()],
+            [teamspace],
+        ]
+    )
+    tx_mock = AsyncMock(return_value={})
+    create_content_mock = AsyncMock(return_value="blob-new-4")
+
+    try:
+        with (
+            patch(
+                "huly_cli.commands.documents.ensure_auth",
+                new=AsyncMock(return_value=fake_auth),
+            ),
+            patch("huly_cli.client.HulyClient.find_all", find_all_mock),
+            patch("huly_cli.client.HulyClient.tx", tx_mock),
+            patch("huly_cli.client.HulyClient.create_content", create_content_mock),
+        ):
+            result = runner.invoke(
+                app,
+                ["--json", "documents", "duplicate", "doc-src", "--title", "Copy"],
+            )
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["ok"] is True
+        assert payload["data"]["id"] == "doc-new"
+        assert payload["data"]["title"] == "Copy"
+        assert payload["data"]["space"] == "Engineering"
+        assert payload["data"]["content_ref"] == "blob-new-4"
+    finally:
+        # Reset module-level JSON mode so subsequent tests see human output.
+        set_json_mode(False)
+
+
+def test_documents_duplicate_source_not_found_gives_clear_error(fake_auth):
+    """Missing source document produces a NotFoundError exit-1 with a clear message."""
+    find_all_mock = AsyncMock(return_value=[])
+
+    with (
+        patch("huly_cli.commands.documents.ensure_auth", new=AsyncMock(return_value=fake_auth)),
+        patch("huly_cli.client.HulyClient.find_all", find_all_mock),
+    ):
+        result = runner.invoke(
+            app,
+            ["documents", "duplicate", "does-not-exist", "--title", "Copy"],
+        )
+
+    assert result.exit_code == 1, result.output
+    assert "does-not-exist" in result.output
+    assert "not found" in result.output.lower()
+
+
+def test_documents_duplicate_missing_title_errors():
+    """--title is required; typer should exit non-zero without attempting any work."""
+    result = runner.invoke(app, ["documents", "duplicate", "doc-src"])
+
+    assert result.exit_code != 0, result.output
+    combined = (result.output + (result.stderr or "")).lower()
+    assert "--title" in combined or "missing option" in combined
+
+
+def test_documents_duplicate_copies_source_content_through_create_content(fake_auth):
+    """The content-copy path uses create_content (new doc starts empty) not set_content."""
+    source = _raw_document(content=_INLINE_MARKUP)
+    new_empty = _raw_document(_id="doc-new", content="")
+
+    find_all_mock = AsyncMock(side_effect=[[source], [new_empty]])
+    tx_mock = AsyncMock(return_value={})
+    create_content_mock = AsyncMock(return_value="blob-new-5")
+    set_content_mock = AsyncMock(return_value=True)
+
+    with (
+        patch("huly_cli.commands.documents.ensure_auth", new=AsyncMock(return_value=fake_auth)),
+        patch("huly_cli.client.HulyClient.find_all", find_all_mock),
+        patch("huly_cli.client.HulyClient.tx", tx_mock),
+        patch("huly_cli.client.HulyClient.create_content", create_content_mock),
+        patch("huly_cli.client.HulyClient.set_content", set_content_mock),
+    ):
+        result = runner.invoke(
+            app,
+            ["documents", "duplicate", "doc-src", "--title", "Copy"],
+        )
+
+    assert result.exit_code == 0, result.output
+    create_content_mock.assert_awaited_once()
+    set_content_mock.assert_not_awaited()


### PR DESCRIPTION
## Summary

Adds a new `huly documents duplicate DOC_ID --title "..."` subcommand that compresses the 4-5 step template-instantiation workflow (describe → save → create → set-file → re-parent) into a single command. Inherits the source's space and parent by default; `--space` or `--parent` override either.

## Changes

- `src/huly_cli/commands/documents.py`
  - Adds the `duplicate` Typer command. Internally composes existing CRUD: `_find_document_by_id` (source + re-fetch), `_resolve_teamspace_by_name` (only when `--space` is passed — branches cleanly to avoid resolving the already-ID source space), `client.tx` for the create, then the same create-content + update-tx path `describe --set-file` uses.
  - Extracts two small private helpers — `_read_doc_markdown(client, doc)` and `_write_markdown_to_doc(client, auth, doc, md)` — so both `describe` and `duplicate` share the inline-vs-blob read path and the create-content write path. `describe --set` now delegates to `_write_markdown_to_doc`.
  - No changes to `client.py`, `markup.py`, or `output.py`.

- `tests/test_issue_write_path.py`
  - Seven `CliRunner` command-layer tests covering: inherited space+parent, `--space` override (teamspace name resolution), `--parent` override, `--json` full-record return, source-not-found error, missing `--title` (required option), and that the content copy path uses `create_content` (not `set_content`) against a brand-new empty doc.
  - Adds a narrow autouse fixture to reset the module-level JSON-mode flag between tests in this file (previously leaked from earlier `--json` tests).

- `README.md` — adds `documents duplicate` to the example command block plus a one-paragraph note on inheritance behavior.
- `skills/huly-cli/SKILL.md` — lists `duplicate` in the documents command surface and adds a short "clone the weekly template" agent workflow example.

## Test plan

- [x] `uv run pytest -x` — 273 tests pass (7 new)
- [x] `uv run ruff format . && uv run ruff check .` — clean
- [x] Scope verified via `git diff master --stat` — only the four allowed files touched; no changes to `client.py`, `markup.py`, `output.py`, or unrelated command modules.
- [x] Behavior covered: default inheritance, both overrides, `--json`, not-found, missing-title, and that new-doc content is written through `create_content` (not `set_content`).

Closes #40