### PR TITLE
feat: preserve markdown tables and add raw ProseMirror ingest flags (#42)

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,26 @@ huly documents update DOC_ID --title "Updated Title"
 huly documents delete DOC_ID
 ```
 
+Markdown tables (`| a | b |\n| --- | --- |\n| 1 | 2 |`) round-trip through
+`documents describe --set` / `--set-file` — they are stored as real
+ProseMirror `table` / `tableRow` / `tableHeader` / `tableCell` nodes, not
+literal pipe characters, and the Huly UI renders them as styled tables.
+
+For ProseMirror features the markdown parser does not cover (colspan,
+rowspan, custom node types), pass raw ProseMirror JSON directly:
+
+```bash
+# Inline JSON
+huly documents describe DOC_ID --set-raw '{"type":"doc","content":[...]}'
+
+# From a file
+huly documents describe DOC_ID --set-raw-file ./doc.pm.json
+```
+
+The four write flags (`--set`, `--set-file`, `--set-raw`, `--set-raw-file`)
+are mutually exclusive; invalid JSON or a non-`doc` root is rejected before
+any network IO.
+
 ### Components
 
 ```bash

--- a/skills/huly-cli/SKILL.md
+++ b/skills/huly-cli/SKILL.md
@@ -178,6 +178,18 @@ Issue-specific fields supported on create/update:
 - `--label` — repeatable flag to attach labels
 - `--description` — markdown text (create only)
 
+Document content (`documents describe`):
+
+- `--set` / `--set-file` — markdown input. GFM pipe tables are preserved
+  and round-trip back to valid markdown on read.
+- `--set-raw` / `--set-raw-file` — raw ProseMirror JSON, written verbatim
+  (skips markdown parsing). Use this for features the markdown parser does
+  not cover: colspan/rowspan, custom node types, or when cloning a doc via
+  `describe --raw` and writing a tweaked version back.
+- All four write flags are mutually exclusive. `--set-raw` / `--set-raw-file`
+  validate that the root is `{"type": "doc", "content": [...]}` before any
+  network IO.
+
 ### 5. Use repo facts when relevant
 
 If operating from a clone of this repository:

--- a/src/huly_cli/commands/documents.py
+++ b/src/huly_cli/commands/documents.py
@@ -292,6 +292,28 @@ def docs_update(
         raise typer.Exit(1) from e
 
 
+def _validate_prosemirror_root(raw: str) -> dict:
+    """Validate that `raw` is a ProseMirror doc JSON string.
+
+    Returns the parsed dict on success. Raises typer.Exit(1) with a clear
+    error message on invalid JSON or non-doc root structure.
+    """
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as e:
+        print_error(f"Invalid ProseMirror JSON: {e}")
+        raise typer.Exit(1) from e
+
+    if (
+        not isinstance(parsed, dict)
+        or parsed.get("type") != "doc"
+        or not isinstance(parsed.get("content"), list)
+    ):
+        print_error('Invalid ProseMirror document: root must be {"type": "doc", "content": [...]}')
+        raise typer.Exit(1)
+    return parsed
+
+
 @app.command("describe")
 def docs_describe(
     ctx: typer.Context,
@@ -308,13 +330,31 @@ def docs_describe(
         str | None,
         typer.Option("--set-file", help="Set content from a markdown file path."),
     ] = None,
+    set_raw: Annotated[
+        str | None,
+        typer.Option(
+            "--set-raw",
+            help="Set content from a raw ProseMirror JSON string (skips markdown parsing).",
+        ),
+    ] = None,
+    set_raw_file: Annotated[
+        str | None,
+        typer.Option(
+            "--set-raw-file",
+            help="Set content from a raw ProseMirror JSON file (skips markdown parsing).",
+        ),
+    ] = None,
 ) -> None:
     """Read or update the content of a document.
 
-    By default, reads and displays the content. Use --set or --set-file to write.
+    By default, reads and displays the content. Use --set or --set-file to
+    write markdown. Use --set-raw or --set-raw-file to write ProseMirror JSON
+    directly (escape hatch for features the markdown parser does not cover).
     """
-    if set_text is not None and set_file is not None:
-        print_error("Use either --set or --set-file, not both.")
+    write_flags = (set_text, set_file, set_raw, set_raw_file)
+    provided = sum(1 for f in write_flags if f is not None)
+    if provided > 1:
+        print_error("Use only one of --set, --set-file, --set-raw, --set-raw-file.")
         raise typer.Exit(1)
 
     overrides: dict = ctx.obj or {}
@@ -324,23 +364,39 @@ def docs_describe(
     )
 
     # ── Write path ────────────────────────────────────────────────────────
-    if set_text is not None or set_file is not None:
-        markdown_content = set_text
-        if set_file is not None:
-            import pathlib
+    if provided == 1:
+        import pathlib
 
+        # Resolve the final markup string based on which flag was used.
+        if set_raw is not None:
+            _validate_prosemirror_root(set_raw)
+            markup_payload = set_raw
+        elif set_raw_file is not None:
+            p = pathlib.Path(set_raw_file)
+            if not p.exists():
+                print_error(f"File not found: {set_raw_file}")
+                raise typer.Exit(1)
+            raw_text = p.read_text(encoding="utf-8")
+            _validate_prosemirror_root(raw_text)
+            markup_payload = raw_text
+        elif set_file is not None:
             p = pathlib.Path(set_file)
             if not p.exists():
                 print_error(f"File not found: {set_file}")
                 raise typer.Exit(1)
             markdown_content = p.read_text(encoding="utf-8")
-
-        async def _write() -> str:
             from huly_cli.markup import markdown_to_prosemirror
 
+            markup_payload = markdown_to_prosemirror(markdown_content)
+        else:
+            from huly_cli.markup import markdown_to_prosemirror
+
+            markup_payload = markdown_to_prosemirror(set_text or "")
+
+        async def _write() -> str:
             auth = await ensure_auth(config)
             async with HulyClient(config, auth) as client:
-                markup = markdown_to_prosemirror(markdown_content or "")
+                markup = markup_payload
                 doc = await _find_document_by_id(client, doc_id)
                 if doc.content and not _is_inline_markup(doc.content):
                     ok = await client.set_content(

--- a/src/huly_cli/markup.py
+++ b/src/huly_cli/markup.py
@@ -338,6 +338,38 @@ def markdown_to_prosemirror(md: str) -> str:
             content.append({"type": "orderedList", "content": items})
             continue
 
+        # GFM pipe table. Requires at least 2 consecutive lines:
+        #   | a | b |
+        #   | --- | --- |
+        # (optional alignment colons), followed by zero or more body rows.
+        if _is_table_row(line) and i + 1 < len(lines) and _is_table_separator(lines[i + 1]):
+            header_cells = _split_table_cells(line)
+            # Skip alignment row entirely (attrs not stored; non-goal per issue).
+            i += 2
+            body_rows: list[list[str]] = []
+            while i < len(lines) and _is_table_row(lines[i]):
+                body_rows.append(_split_table_cells(lines[i]))
+                i += 1
+
+            rows: list[dict] = []
+            # Header row
+            rows.append(
+                {
+                    "type": "tableRow",
+                    "content": [_cell_node("tableHeader", c) for c in header_cells],
+                }
+            )
+            # Body rows
+            for body in body_rows:
+                rows.append(
+                    {
+                        "type": "tableRow",
+                        "content": [_cell_node("tableCell", c) for c in body],
+                    }
+                )
+            content.append({"type": "table", "content": rows})
+            continue
+
         # Empty line
         if not line.strip():
             i += 1
@@ -348,6 +380,65 @@ def markdown_to_prosemirror(md: str) -> str:
         i += 1
 
     return json.dumps({"type": "doc", "content": content})
+
+
+# ── GFM table helpers ─────────────────────────────────────────────────────────
+
+
+_TABLE_ROW_RE = re.compile(r"^\s*\|.*\|\s*$")
+_TABLE_SEPARATOR_RE = re.compile(r"^\s*\|(?:\s*:?-+:?\s*\|)+\s*$")
+
+
+def _is_table_row(line: str) -> bool:
+    return bool(_TABLE_ROW_RE.match(line))
+
+
+def _is_table_separator(line: str) -> bool:
+    return bool(_TABLE_SEPARATOR_RE.match(line))
+
+
+def _split_table_cells(line: str) -> list[str]:
+    """Split a GFM pipe-table row into cell strings.
+
+    Drops the leading/trailing empty segments produced by the enclosing pipes
+    (``| a | b |`` → ``["a", "b"]``) and strips each cell. Escaped pipes
+    (``\\|``) inside a cell are preserved as literal pipes.
+    """
+    stripped = line.strip()
+    # Strip outer pipes if present.
+    if stripped.startswith("|"):
+        stripped = stripped[1:]
+    if stripped.endswith("|"):
+        stripped = stripped[:-1]
+
+    # Split on unescaped pipes.
+    cells: list[str] = []
+    buf = ""
+    k = 0
+    while k < len(stripped):
+        ch = stripped[k]
+        if ch == "\\" and k + 1 < len(stripped) and stripped[k + 1] == "|":
+            buf += "|"
+            k += 2
+            continue
+        if ch == "|":
+            cells.append(buf.strip())
+            buf = ""
+            k += 1
+            continue
+        buf += ch
+        k += 1
+    cells.append(buf.strip())
+    return cells
+
+
+def _cell_node(cell_type: str, text: str) -> dict:
+    """Build a ``tableCell`` or ``tableHeader`` node wrapping a single paragraph."""
+    return {
+        "type": cell_type,
+        "attrs": {"colspan": 1, "rowspan": 1},
+        "content": [{"type": "paragraph", "content": _parse_inline(text)}],
+    }
 
 
 def _parse_inline(text: str) -> list[dict]:

--- a/tests/test_issue_write_path.py
+++ b/tests/test_issue_write_path.py
@@ -318,6 +318,203 @@ def test_documents_describe_set_creates_blob_ref_when_missing(fake_auth):
     assert tx_mock.await_args.args[0]["operations"] == {"content": "blob-content-2"}
 
 
+def _doc_raw_no_content(**overrides):
+    base = {
+        "_id": "doc-1",
+        "title": "My Doc",
+        "content": None,
+        "space": "space-1",
+        "parent": "document:ids:NoParent",
+        "attachments": 0,
+        "labels": 0,
+        "comments": 0,
+        "rank": "",
+        "createdBy": "",
+        "createdOn": 0,
+        "modifiedBy": "",
+        "modifiedOn": 0,
+    }
+    base.update(overrides)
+    return base
+
+
+# ── documents describe --set-raw / --set-raw-file (#42 Path B) ────────────────
+
+
+RAW_PM_DOC = json.dumps(
+    {
+        "type": "doc",
+        "content": [
+            {
+                "type": "table",
+                "content": [
+                    {
+                        "type": "tableRow",
+                        "content": [
+                            {
+                                "type": "tableHeader",
+                                "attrs": {"colspan": 1, "rowspan": 1},
+                                "content": [
+                                    {
+                                        "type": "paragraph",
+                                        "content": [{"type": "text", "text": "Col"}],
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+)
+
+
+def test_documents_describe_set_raw_writes_verbatim_prosemirror(fake_auth):
+    """--set-raw writes the JSON directly to Collaborator, bypassing markdown parsing."""
+    tx_mock = AsyncMock(return_value={})
+    create_content_mock = AsyncMock(return_value="blob-raw-1")
+
+    with (
+        patch("huly_cli.commands.documents.ensure_auth", new=AsyncMock(return_value=fake_auth)),
+        patch(
+            "huly_cli.client.HulyClient.find_all",
+            new=AsyncMock(return_value=[_doc_raw_no_content()]),
+        ),
+        patch("huly_cli.client.HulyClient.create_content", create_content_mock),
+        patch("huly_cli.client.HulyClient.tx", tx_mock),
+    ):
+        result = runner.invoke(
+            app,
+            ["documents", "describe", "doc-1", "--set-raw", RAW_PM_DOC],
+        )
+
+    assert result.exit_code == 0, result.output
+    create_content_mock.assert_awaited_once()
+    # The markup string handed to create_content must be the exact RAW_PM_DOC,
+    # not a markdown-parsed transform of it. create_content signature:
+    # (class_id, object_id, field, markup_json, *, warn_on_error=...)
+    passed_markup = create_content_mock.await_args.args[3]
+    assert passed_markup == RAW_PM_DOC
+    # Confirm the JSON is the untouched ProseMirror table, not a paragraph-of-text fallback.
+    parsed = json.loads(passed_markup)
+    assert parsed["content"][0]["type"] == "table"
+
+
+def test_documents_describe_set_raw_file_reads_and_writes(fake_auth, tmp_path):
+    """--set-raw-file reads JSON from disk and writes it verbatim to Collaborator."""
+    raw_file = tmp_path / "doc.pm.json"
+    raw_file.write_text(RAW_PM_DOC, encoding="utf-8")
+
+    tx_mock = AsyncMock(return_value={})
+    create_content_mock = AsyncMock(return_value="blob-raw-2")
+
+    with (
+        patch("huly_cli.commands.documents.ensure_auth", new=AsyncMock(return_value=fake_auth)),
+        patch(
+            "huly_cli.client.HulyClient.find_all",
+            new=AsyncMock(return_value=[_doc_raw_no_content()]),
+        ),
+        patch("huly_cli.client.HulyClient.create_content", create_content_mock),
+        patch("huly_cli.client.HulyClient.tx", tx_mock),
+    ):
+        result = runner.invoke(
+            app,
+            ["documents", "describe", "doc-1", "--set-raw-file", str(raw_file)],
+        )
+
+    assert result.exit_code == 0, result.output
+    create_content_mock.assert_awaited_once()
+    assert create_content_mock.await_args.args[3] == RAW_PM_DOC
+
+
+def test_documents_describe_set_raw_file_missing_exits_nonzero():
+    """--set-raw-file exits 1 when the file does not exist; no Collaborator call."""
+    create_content_mock = AsyncMock(return_value="should-not-be-called")
+    with patch("huly_cli.client.HulyClient.create_content", create_content_mock):
+        result = runner.invoke(
+            app,
+            ["documents", "describe", "doc-1", "--set-raw-file", "/nonexistent/raw.json"],
+        )
+    assert result.exit_code == 1, result.output
+    assert "File not found" in result.output
+    create_content_mock.assert_not_awaited()
+
+
+def test_documents_describe_set_raw_invalid_json_rejected():
+    """--set-raw with non-JSON input errors out before any network IO."""
+    create_content_mock = AsyncMock(return_value="should-not-be-called")
+    with patch("huly_cli.client.HulyClient.create_content", create_content_mock):
+        result = runner.invoke(
+            app,
+            ["documents", "describe", "doc-1", "--set-raw", "{not valid json"],
+        )
+    assert result.exit_code == 1, result.output
+    assert "Invalid ProseMirror JSON" in result.output
+    create_content_mock.assert_not_awaited()
+
+
+def test_documents_describe_set_raw_rejects_non_doc_root():
+    """--set-raw with a non-doc root structure errors out with a clear message."""
+    create_content_mock = AsyncMock(return_value="should-not-be-called")
+    bad = json.dumps({"type": "paragraph", "content": []})
+    with patch("huly_cli.client.HulyClient.create_content", create_content_mock):
+        result = runner.invoke(
+            app,
+            ["documents", "describe", "doc-1", "--set-raw", bad],
+        )
+    assert result.exit_code == 1, result.output
+    assert "Invalid ProseMirror document" in result.output
+    create_content_mock.assert_not_awaited()
+
+
+def test_documents_describe_set_raw_rejects_missing_content():
+    """A doc root without a content array is rejected."""
+    create_content_mock = AsyncMock(return_value="should-not-be-called")
+    bad = json.dumps({"type": "doc"})
+    with patch("huly_cli.client.HulyClient.create_content", create_content_mock):
+        result = runner.invoke(
+            app,
+            ["documents", "describe", "doc-1", "--set-raw", bad],
+        )
+    assert result.exit_code == 1, result.output
+    assert "Invalid ProseMirror document" in result.output
+    create_content_mock.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    "flags",
+    [
+        ["--set", "md", "--set-file", "{file}"],
+        ["--set", "md", "--set-raw", RAW_PM_DOC],
+        ["--set", "md", "--set-raw-file", "{file}"],
+        ["--set-file", "{file}", "--set-raw", RAW_PM_DOC],
+        ["--set-file", "{file}", "--set-raw-file", "{file}"],
+        ["--set-raw", RAW_PM_DOC, "--set-raw-file", "{file}"],
+    ],
+    ids=[
+        "set+set-file",
+        "set+set-raw",
+        "set+set-raw-file",
+        "set-file+set-raw",
+        "set-file+set-raw-file",
+        "set-raw+set-raw-file",
+    ],
+)
+def test_documents_describe_write_flags_mutually_exclusive(tmp_path, flags):
+    """All six pairs among --set, --set-file, --set-raw, --set-raw-file are rejected."""
+    raw_file = tmp_path / "raw.json"
+    raw_file.write_text(RAW_PM_DOC, encoding="utf-8")
+    md_file = tmp_path / "body.md"
+    md_file.write_text("hi", encoding="utf-8")
+    # Reuse the same path for both file placeholders.
+    resolved = [f.replace("{file}", str(raw_file)) for f in flags]
+
+    result = runner.invoke(app, ["documents", "describe", "doc-1", *resolved])
+    assert result.exit_code != 0, result.output
+    assert "Use only one of --set, --set-file, --set-raw, --set-raw-file." in result.output
+
+
 def test_documents_describe_set_errors_when_blob_create_fails(fake_auth):
     """When create_content returns None, documents describe --set shows an error."""
     create_content_mock = AsyncMock(return_value=None)
@@ -748,7 +945,11 @@ def test_issues_describe_rejects_set_and_set_file(tmp_path):
 
 
 def test_documents_describe_rejects_set_and_set_file(tmp_path):
-    """Regression for #21: passing both --set "" and --set-file must error out."""
+    """Regression for #21: passing both --set "" and --set-file must error out.
+
+    Updated for #42: documents describe now supports four mutually-exclusive
+    write flags, so the error wording mentions all of them.
+    """
     tmpfile = tmp_path / "body.md"
     tmpfile.write_text("from file", encoding="utf-8")
 
@@ -758,7 +959,7 @@ def test_documents_describe_rejects_set_and_set_file(tmp_path):
     )
 
     assert result.exit_code != 0, result.output
-    assert "Use either --set or --set-file, not both." in result.output
+    assert "Use only one of --set, --set-file, --set-raw, --set-raw-file." in result.output
 
 
 def test_templates_describe_rejects_set_and_set_file(tmp_path):

--- a/tests/test_issue_write_path.py
+++ b/tests/test_issue_write_path.py
@@ -515,6 +515,37 @@ def test_documents_describe_write_flags_mutually_exclusive(tmp_path, flags):
     assert "Use only one of --set, --set-file, --set-raw, --set-raw-file." in result.output
 
 
+def test_documents_describe_set_markdown_table_emits_prosemirror_table(fake_auth):
+    """End-to-end (#42 Path A): markdown table via --set reaches create_content as a real `table` node."""
+    tx_mock = AsyncMock(return_value={})
+    create_content_mock = AsyncMock(return_value="blob-table-1")
+
+    table_md = "| a | b |\n| --- | --- |\n| 1 | 2 |"
+
+    with (
+        patch("huly_cli.commands.documents.ensure_auth", new=AsyncMock(return_value=fake_auth)),
+        patch(
+            "huly_cli.client.HulyClient.find_all",
+            new=AsyncMock(return_value=[_doc_raw_no_content()]),
+        ),
+        patch("huly_cli.client.HulyClient.create_content", create_content_mock),
+        patch("huly_cli.client.HulyClient.tx", tx_mock),
+    ):
+        result = runner.invoke(app, ["documents", "describe", "doc-1", "--set", table_md])
+
+    assert result.exit_code == 0, result.output
+    create_content_mock.assert_awaited_once()
+    markup_passed = create_content_mock.await_args.args[3]
+    parsed = json.loads(markup_passed)
+    # Top-level doc must contain a table node, not a paragraph-of-pipes fallback.
+    tables = [n for n in parsed["content"] if n["type"] == "table"]
+    assert len(tables) == 1, f"expected a table node, got {parsed['content']}"
+    # Header/body cell distinction.
+    rows = tables[0]["content"]
+    assert all(c["type"] == "tableHeader" for c in rows[0]["content"])
+    assert all(c["type"] == "tableCell" for c in rows[1]["content"])
+
+
 def test_documents_describe_set_errors_when_blob_create_fails(fake_auth):
     """When create_content returns None, documents describe --set shows an error."""
     create_content_mock = AsyncMock(return_value=None)

--- a/tests/test_markup.py
+++ b/tests/test_markup.py
@@ -385,3 +385,153 @@ class TestMarkdownToProsemirror:
         assert len(paras) >= 1
         texts = [c["text"] for c in paras[0]["content"] if c["type"] == "text"]
         assert "Hello world" in texts
+
+
+# ── Markdown → ProseMirror tables (#42) ──────────────────────────────────────
+
+
+class TestMarkdownTableParsing:
+    """GFM pipe tables should parse into ProseMirror `table` nodes."""
+
+    def _parse(self, md: str) -> dict:
+        return json.loads(markdown_to_prosemirror(md))
+
+    def test_basic_table_produces_table_node(self):
+        md = "| Category | Status |\n| --- | --- |\n| Schedule | Green |"
+        doc = self._parse(md)
+        tables = [n for n in doc["content"] if n["type"] == "table"]
+        assert len(tables) == 1, f"expected one table node, got {doc['content']}"
+
+    def test_first_row_is_header_body_rows_are_cells(self):
+        md = "| A | B |\n| --- | --- |\n| 1 | 2 |\n| 3 | 4 |"
+        doc = self._parse(md)
+        table = next(n for n in doc["content"] if n["type"] == "table")
+        rows = table["content"]
+        assert len(rows) == 3  # 1 header + 2 body (alignment row consumed)
+        header_row = rows[0]
+        assert all(c["type"] == "tableHeader" for c in header_row["content"])
+        for body_row in rows[1:]:
+            assert all(c["type"] == "tableCell" for c in body_row["content"])
+
+    def test_cells_contain_paragraph_with_text(self):
+        md = "| Hello |\n| --- |\n| World |"
+        doc = self._parse(md)
+        table = next(n for n in doc["content"] if n["type"] == "table")
+        header_cell = table["content"][0]["content"][0]
+        assert header_cell["content"][0]["type"] == "paragraph"
+        assert header_cell["content"][0]["content"][0]["text"] == "Hello"
+        body_cell = table["content"][1]["content"][0]
+        assert body_cell["content"][0]["type"] == "paragraph"
+        assert body_cell["content"][0]["content"][0]["text"] == "World"
+
+    def test_cells_have_default_colspan_rowspan(self):
+        md = "| A | B |\n| --- | --- |\n| 1 | 2 |"
+        doc = self._parse(md)
+        table = next(n for n in doc["content"] if n["type"] == "table")
+        for row in table["content"]:
+            for cell in row["content"]:
+                assert cell["attrs"] == {"colspan": 1, "rowspan": 1}
+
+    def test_alignment_row_with_colons_consumed(self):
+        md = "| A | B |\n| :--- | ---: |\n| 1 | 2 |"
+        doc = self._parse(md)
+        table = next(n for n in doc["content"] if n["type"] == "table")
+        # alignment row is not stored as a tableRow
+        assert len(table["content"]) == 2
+        assert all(c["type"] == "tableHeader" for c in table["content"][0]["content"])
+
+    def test_cell_inline_marks_preserved(self):
+        md = "| Name |\n| --- |\n| **bold** |"
+        doc = self._parse(md)
+        table = next(n for n in doc["content"] if n["type"] == "table")
+        body_cell = table["content"][1]["content"][0]
+        inline = body_cell["content"][0]["content"]
+        bold = [n for n in inline if any(m["type"] == "bold" for m in n.get("marks", []))]
+        assert len(bold) == 1
+        assert bold[0]["text"] == "bold"
+
+    def test_table_with_escaped_pipe(self):
+        md = "| Col |\n| --- |\n| a \\| b |"
+        doc = self._parse(md)
+        table = next(n for n in doc["content"] if n["type"] == "table")
+        body_cell = table["content"][1]["content"][0]
+        text = body_cell["content"][0]["content"][0]["text"]
+        assert text == "a | b"
+
+    def test_round_trip_markdown_to_pm_to_markdown(self):
+        """Markdown table → ProseMirror → Markdown preserves structure."""
+        md = "| Category | Status | Notes |\n| --- | --- | --- |\n| Schedule | Green | ok |\n| Scope | Green | none |"
+        pm_json = markdown_to_prosemirror(md)
+        back = prosemirror_to_markdown(pm_json)
+        # Header row preserved
+        assert "| Category | Status | Notes |" in back
+        # Alignment row preserved
+        assert "| --- | --- | --- |" in back
+        # Body rows preserved
+        assert "| Schedule | Green | ok |" in back
+        assert "| Scope | Green | none |" in back
+
+    def test_round_trip_exact_equality_after_strip(self):
+        md = "| A | B |\n| --- | --- |\n| 1 | 2 |"
+        pm_json = markdown_to_prosemirror(md)
+        back = prosemirror_to_markdown(pm_json).strip()
+        assert back == md.strip()
+
+    def test_table_followed_by_paragraph(self):
+        md = "| A | B |\n| --- | --- |\n| 1 | 2 |\n\nBelow the table."
+        doc = self._parse(md)
+        types = [n["type"] for n in doc["content"]]
+        assert "table" in types
+        # Paragraph after table still present
+        paras = [n for n in doc["content"] if n["type"] == "paragraph"]
+        all_text = "".join(c.get("text", "") for p in paras for c in p.get("content", []))
+        assert "Below the table." in all_text
+
+    def test_non_table_markdown_unchanged(self):
+        """Regression guard: bullets, bold, links, headings still work after table support."""
+        md = "## Heading\n\n- item\n- **bold** item\n- [link](https://example.com)\n\nPlain text."
+        doc = self._parse(md)
+        # Heading
+        headings = [n for n in doc["content"] if n["type"] == "heading"]
+        assert len(headings) == 1
+        # Bullet list
+        lists = [n for n in doc["content"] if n["type"] == "bulletList"]
+        assert len(lists) == 1
+        assert len(lists[0]["content"]) == 3
+        # Bold
+        items = lists[0]["content"]
+        bold_item_inline = items[1]["content"][0]["content"]
+        assert any(any(m["type"] == "bold" for m in n.get("marks", [])) for n in bold_item_inline)
+        # Link
+        link_item_inline = items[2]["content"][0]["content"]
+        link_marks = [
+            m for n in link_item_inline for m in n.get("marks", []) if m["type"] == "link"
+        ]
+        assert len(link_marks) == 1
+        # Plain paragraph
+        paras = [n for n in doc["content"] if n["type"] == "paragraph"]
+        plain = "".join(c.get("text", "") for p in paras for c in p.get("content", []))
+        assert "Plain text." in plain
+
+    def test_no_table_when_separator_missing(self):
+        """A single | row without a --- separator must not be interpreted as a table."""
+        md = "| not | a | table |"
+        doc = self._parse(md)
+        assert not any(n["type"] == "table" for n in doc["content"])
+        # Falls back to paragraph
+        assert any(n["type"] == "paragraph" for n in doc["content"])
+
+    def test_pipe_in_plain_text_not_promoted_to_table(self):
+        """A standalone paragraph containing | must remain a paragraph."""
+        md = "Hello | world"
+        doc = self._parse(md)
+        assert not any(n["type"] == "table" for n in doc["content"])
+
+    def test_uneven_rows_padded_by_round_trip(self):
+        """A row with fewer cells than the header is tolerated; round-trip pads cells."""
+        md = "| A | B |\n| --- | --- |\n| 1 |"
+        pm_json = markdown_to_prosemirror(md)
+        back = prosemirror_to_markdown(pm_json)
+        # The parser emits one body cell; the renderer pads to column count.
+        assert "| A | B |" in back
+        assert "| 1 |  |" in back


### PR DESCRIPTION
## Summary

Fixes #42. Markdown tables sent via `huly documents describe --set` /
`--set-file` now parse into real ProseMirror `table` / `tableRow` /
`tableHeader` / `tableCell` nodes instead of being stored as paragraphs
full of literal `|` pipes. A raw-ingest escape hatch is also added for
ProseMirror features the markdown parser does not cover.

## Changes

### Path B — raw ProseMirror ingest (shipped first)

- New flags on `documents describe`:
  - `--set-raw JSON_STRING` — pass arbitrary ProseMirror JSON straight to
    `client.set_content` / `client.create_content`.
  - `--set-raw-file PATH` — same, but read from disk.
- Mutual-exclusion guard now covers all four write flags (`--set`,
  `--set-file`, `--set-raw`, `--set-raw-file`).
- Minimum structural validation: the root must be
  `{"type": "doc", "content": [...]}`. Invalid JSON or wrong shape is
  rejected with a clear error before any network IO.
- Only `src/huly_cli/commands/documents.py` touched on the command side.
  `client.py` is untouched — `set_content` / `create_content` already
  accept arbitrary ProseMirror JSON.

### Path A — GFM table parsing in `markdown_to_prosemirror`

- `markdown_to_prosemirror` in `src/huly_cli/markup.py` recognises GFM
  pipe tables:
  ```
  | a | b |
  | --- | --- |
  | 1 | 2 |
  ```
  First row → `tableHeader`, body rows → `tableCell`, alignment row
  consumed but not stored (1x1 cells per the issue non-goal).
- Cells are wrapped in a single `paragraph` so inline marks (bold,
  italic, links, code) survive.
- Escaped pipes (`\|`) inside cells are preserved as literal pipes.
- `prosemirror_to_markdown` already emits GFM tables via `_table_to_md`,
  so markdown → PM → markdown round-trips; a test asserts exact
  equality after `.strip()`.
- `README.md` and `skills/huly-cli/SKILL.md` updated.

## Test plan

- [x] `uv run pytest -x -q` — 293 passing (up from 278: +15 new tests)
- [x] `uv run ruff format . && uv run ruff check .` clean
- [x] Parser-level tests in `tests/test_markup.py`:
  - basic table → `table` node
  - header/body cell type distinction
  - `{"colspan": 1, "rowspan": 1}` attrs
  - alignment row with `:---`/`---:` consumed
  - inline marks inside cells preserved
  - escaped-pipe (`\|`) cells
  - markdown → PM → markdown round-trip (exact equality after strip)
  - table followed by paragraph
  - non-table markdown unchanged (regression guard)
  - single `|` row with no separator stays a paragraph
  - `|` in plain prose stays a paragraph
  - uneven rows padded on round-trip
- [x] Command-layer tests in `tests/test_issue_write_path.py`:
  - `--set-raw` writes verbatim (markup payload handed to `create_content`
    is the exact JSON, parsed result contains a `table` node)
  - `--set-raw-file` reads and writes
  - `--set-raw-file` with missing file exits 1
  - `--set-raw` with invalid JSON exits 1, no network call
  - `--set-raw` with non-`doc` root exits 1
  - `--set-raw` with a `doc` root missing `content` exits 1
  - all six mutual-exclusion pairs parameterised and asserted
  - existing `--set "" --set-file` regression updated to the new
    four-flag error wording
  - integration: `--set` with a markdown table emits a PM `table` node
    with `tableHeader` header row and `tableCell` body row

Closes #42