### PR TITLE
fix: autolink every bare URL in descriptions (#49)

### DIFF
--- a/src/huly_cli/markup.py
+++ b/src/huly_cli/markup.py
@@ -166,7 +166,8 @@ def _inline_to_md(nodes: list[Any]) -> str:
             continue
         node_type = node.get("type", "")
         if node_type == "text":
-            text = node.get("text", "")
+            original = node.get("text", "")
+            text = original
             marks = node.get("marks", [])
             mark_types = {m.get("type") for m in marks}
             if "code" in mark_types:
@@ -182,7 +183,10 @@ def _inline_to_md(nodes: list[Any]) -> str:
             for m in marks:
                 if m.get("type") == "link":
                     href = m.get("attrs", {}).get("href", "")
-                    text = f"[{text}]({href})"
+                    if mark_types == {"link"} and original == href:
+                        text = href
+                    else:
+                        text = f"[{text}]({href})"
             result += text
         elif node_type == "hardBreak":
             result += "\n"
@@ -443,15 +447,18 @@ def _cell_node(cell_type: str, text: str) -> dict:
 
 def _parse_inline(text: str) -> list[dict]:
     """Parse inline markdown (bold, italic, code, links) into ProseMirror inline nodes."""
-    # Pattern order matters: code > bold+italic > bold > italic > link
+    # Pattern order matters: code > bold+italic > bold > italic > link > autolink.
+    # The bare-URL autolink (group 10) intentionally comes after the explicit
+    # ``[text](url)`` link form so a markdown link is preferred when both could match.
     pattern = re.compile(
-        r"(`[^`]+`)"  # inline code
-        r"|(\*\*\*[^*]+\*\*\*)"  # bold+italic ***
-        r"|(\*\*[^*]+\*\*)"  # bold **
-        r"|(\*[^*]+\*)"  # italic *
-        r"|(_[^_]+_)"  # italic _
-        r"|(~~[^~]+~~)"  # strikethrough
-        r"|(\[([^\]]+)\]\(([^)]+)\))"  # link [text](url)
+        r"(`[^`]+`)"  # 1: inline code
+        r"|(\*\*\*[^*]+\*\*\*)"  # 2: bold+italic ***
+        r"|(\*\*[^*]+\*\*)"  # 3: bold **
+        r"|(\*[^*]+\*)"  # 4: italic *
+        r"|(_[^_]+_)"  # 5: italic _
+        r"|(~~[^~]+~~)"  # 6: strikethrough
+        r"|(\[([^\]]+)\]\(([^)]+)\))"  # 7,8,9: link [text](url)
+        r"|(https?://[^\s<>\[\]`]+)"  # 10: bare URL autolink
     )
 
     runs: list[dict] = []
@@ -490,9 +497,46 @@ def _parse_inline(text: str) -> list[dict]:
                     "marks": [{"type": "link", "attrs": {"href": href, "target": "_blank"}}],
                 }
             )
+        elif m.group(10):  # bare URL autolink
+            url, trailing = _split_url_trailing_punct(m.group(10))
+            runs.append(
+                {
+                    "type": "text",
+                    "text": url,
+                    "marks": [{"type": "link", "attrs": {"href": url, "target": "_blank"}}],
+                }
+            )
+            if trailing:
+                runs.append({"type": "text", "text": trailing})
 
     # Trailing plain text
     if last < len(text):
         runs.append({"type": "text", "text": text[last:]})
 
     return runs if runs else [{"type": "text", "text": text}]
+
+
+def _split_url_trailing_punct(url: str) -> tuple[str, str]:
+    """Split sentence-level punctuation off the tail of an autolinked URL.
+
+    Greedy URL matching pulls in trailing characters that almost certainly
+    belong to the surrounding prose, not the URL itself: a period at the end
+    of a sentence, a comma in a list, an unbalanced closing bracket from
+    ``(see https://x.com)``. Strip those, but leave balanced brackets intact
+    so URLs like ``https://en.wikipedia.org/wiki/Foo_(bar)`` survive.
+    """
+    trailing = ""
+    while url:
+        last = url[-1]
+        if last in ".,;:!?":
+            trailing = last + trailing
+            url = url[:-1]
+        elif last == ")" and url.count("(") < url.count(")"):
+            trailing = last + trailing
+            url = url[:-1]
+        elif last == "]" and url.count("[") < url.count("]"):
+            trailing = last + trailing
+            url = url[:-1]
+        else:
+            break
+    return url, trailing

--- a/tests/test_issue_write_path.py
+++ b/tests/test_issue_write_path.py
@@ -204,6 +204,83 @@ async def test_create_impl_skips_description_tx_when_no_description_provided(
     create_description_mock.assert_not_awaited()
 
 
+async def test_create_impl_autolinks_every_url_in_description(fake_config, fake_auth):
+    """Regression for #49: every bare URL in a pasted description must be linked.
+
+    Previously the markdown→ProseMirror conversion only emitted a `link` mark
+    for the first URL on a line (or only the explicit `[text](url)` form),
+    leaving the remaining URLs as plain text. The submitted ProseMirror payload
+    must carry one link mark per URL so the rendered ticket doesn't depend on
+    the UI's autolinker — which only handles the first URL on paste.
+    """
+    project_doc = {
+        "_id": "project-1",
+        "name": "My Project",
+        "identifier": "DEMO",
+        "sequence": 16,
+        "members": [],
+        "owners": [],
+        "description": "",
+        "defaultIssueStatus": "tracker:status:Backlog",
+        "private": False,
+        "archived": False,
+    }
+    find_all_mock = AsyncMock(
+        side_effect=[
+            [project_doc],
+            [{"_id": "issue-16", "rank": "0|i0002f:", "space": "project-1"}],
+        ]
+    )
+    tx_mock = AsyncMock(side_effect=[{"object": {"sequence": 17}}, {}, {}])
+    create_description_mock = AsyncMock(return_value="blob-description-49")
+
+    description = (
+        "- Subject: A | Gmail link: https://mail.google.com/mail/#all/19d91c48eb9ff376\n"
+        "- Subject: B | Gmail link: https://mail.google.com/mail/#all/19d8f9739e371daf\n"
+        "- Subject: C | Gmail link: https://mail.google.com/mail/#all/19d8c8389dde5065"
+    )
+
+    with (
+        patch("huly_cli.commands.issues.ensure_auth", new=AsyncMock(return_value=fake_auth)),
+        patch("huly_cli.client.HulyClient.find_all", find_all_mock),
+        patch("huly_cli.client.HulyClient.tx", tx_mock),
+        patch("huly_cli.client.HulyClient.create_description", create_description_mock),
+    ):
+        await issues_cmd._create_impl(
+            fake_config,
+            title="Multiple URLs",
+            project="DEMO",
+            status=None,
+            priority="medium",
+            assignee=None,
+            description=description,
+        )
+
+    create_description_mock.assert_awaited_once()
+    markup_json = create_description_mock.await_args.args[1]
+    pm_doc = json.loads(markup_json)
+
+    # Walk the document and collect every link href.
+    hrefs: list[str] = []
+
+    def _walk(node: object) -> None:
+        if not isinstance(node, dict):
+            return
+        for mark in node.get("marks", []) or []:
+            if mark.get("type") == "link":
+                hrefs.append(mark.get("attrs", {}).get("href", ""))
+        for child in node.get("content", []) or []:
+            _walk(child)
+
+    _walk(pm_doc)
+
+    assert hrefs == [
+        "https://mail.google.com/mail/#all/19d91c48eb9ff376",
+        "https://mail.google.com/mail/#all/19d8f9739e371daf",
+        "https://mail.google.com/mail/#all/19d8c8389dde5065",
+    ], f"expected one link mark per URL, got {hrefs!r}"
+
+
 async def test_update_impl_resolves_custom_status_and_unassigns(fake_config, fake_auth):
     issue = Issue.model_validate(_raw_issue(space="project-1"))
     tx_mock = AsyncMock(return_value={})

--- a/tests/test_markup.py
+++ b/tests/test_markup.py
@@ -387,6 +387,115 @@ class TestMarkdownToProsemirror:
         assert "Hello world" in texts
 
 
+# ── Markdown → ProseMirror autolinks (#49) ───────────────────────────────────
+
+
+def _link_marks(inline_nodes: list[dict]) -> list[dict]:
+    """Pull every `link` mark off a list of inline ProseMirror nodes."""
+    return [m for n in inline_nodes for m in n.get("marks", []) if m.get("type") == "link"]
+
+
+def _link_hrefs(inline_nodes: list[dict]) -> list[str]:
+    return [m.get("attrs", {}).get("href", "") for m in _link_marks(inline_nodes)]
+
+
+class TestMarkdownAutolinks:
+    """Bare ``https://...`` URLs should each become a ProseMirror link mark.
+
+    Regression for #49: previously only the first URL in a pasted body was
+    linked; the rest stayed as plain text.
+    """
+
+    def _inline(self, md: str) -> list[dict]:
+        doc = json.loads(markdown_to_prosemirror(md))
+        paras = [n for n in doc["content"] if n["type"] == "paragraph"]
+        # Flatten inline content from every paragraph into one list.
+        return [c for p in paras for c in p.get("content", [])]
+
+    def test_single_bare_url_becomes_link(self):
+        inline = self._inline("see https://example.com please")
+        hrefs = _link_hrefs(inline)
+        assert hrefs == ["https://example.com"]
+        # Surrounding text is preserved.
+        all_text = "".join(n.get("text", "") for n in inline)
+        assert all_text == "see https://example.com please"
+
+    def test_two_urls_on_same_line_both_linked(self):
+        # Mirrors the bug's exact " | " separator shape.
+        md = "Subject: A | link: https://a.example.com/x | link: https://b.example.com/y"
+        inline = self._inline(md)
+        assert _link_hrefs(inline) == [
+            "https://a.example.com/x",
+            "https://b.example.com/y",
+        ]
+
+    def test_three_urls_across_lines_all_linked(self):
+        md = (
+            "- Subject: A | Gmail link: https://mail.google.com/mail/#all/19d91c48eb9ff376\n"
+            "- Subject: B | Gmail link: https://mail.google.com/mail/#all/19d8f9739e371daf\n"
+            "- Subject: C | Gmail link: https://mail.google.com/mail/#all/19d8c8389dde5065\n"
+        )
+        doc = json.loads(markdown_to_prosemirror(md))
+        # Each line becomes a bullet listItem; flatten all link hrefs from all items.
+        bullet = next(n for n in doc["content"] if n["type"] == "bulletList")
+        all_hrefs: list[str] = []
+        for item in bullet["content"]:
+            for para in item["content"]:
+                if para.get("type") == "paragraph":
+                    all_hrefs.extend(_link_hrefs(para["content"]))
+        assert all_hrefs == [
+            "https://mail.google.com/mail/#all/19d91c48eb9ff376",
+            "https://mail.google.com/mail/#all/19d8f9739e371daf",
+            "https://mail.google.com/mail/#all/19d8c8389dde5065",
+        ]
+
+    def test_trailing_period_not_part_of_href(self):
+        inline = self._inline("Visit https://example.com.")
+        assert _link_hrefs(inline) == ["https://example.com"]
+        all_text = "".join(n.get("text", "") for n in inline)
+        assert all_text.endswith(".")
+
+    def test_trailing_comma_not_part_of_href(self):
+        inline = self._inline("see https://a.example.com, then https://b.example.com")
+        assert _link_hrefs(inline) == [
+            "https://a.example.com",
+            "https://b.example.com",
+        ]
+
+    def test_unbalanced_closing_paren_not_part_of_href(self):
+        # "(see https://example.com)" — the trailing ')' belongs to the prose.
+        inline = self._inline("(see https://example.com)")
+        assert _link_hrefs(inline) == ["https://example.com"]
+        all_text = "".join(n.get("text", "") for n in inline)
+        assert all_text == "(see https://example.com)"
+
+    def test_balanced_parens_kept_in_href(self):
+        # Wikipedia-style URLs with balanced parens are preserved verbatim.
+        inline = self._inline("ref: https://en.wikipedia.org/wiki/Foo_(bar)")
+        assert _link_hrefs(inline) == ["https://en.wikipedia.org/wiki/Foo_(bar)"]
+
+    def test_explicit_markdown_link_still_uses_label(self):
+        # `[click](url)` must NOT be misparsed as a bare URL — the label must win.
+        inline = self._inline("[click](https://example.com)")
+        link_nodes = [n for n in inline if _link_marks([n])]
+        assert len(link_nodes) == 1
+        assert link_nodes[0]["text"] == "click"
+        assert _link_hrefs(inline) == ["https://example.com"]
+
+    def test_http_scheme_also_autolinked(self):
+        inline = self._inline("see http://example.com here")
+        assert _link_hrefs(inline) == ["http://example.com"]
+
+    def test_bare_url_round_trips_back_to_bare_url(self):
+        # Markdown → ProseMirror → Markdown should keep "https://x.com" as-is,
+        # not expand it to "[https://x.com](https://x.com)".
+        md = "see https://example.com here"
+        pm_json = markdown_to_prosemirror(md)
+        back = prosemirror_to_markdown(pm_json)
+        assert "https://example.com" in back
+        assert "[https://example.com]" not in back
+
+
 # ── Markdown → ProseMirror tables (#42) ──────────────────────────────────────
 
 


### PR DESCRIPTION
Closes #49.

## Summary
- The markdown → ProseMirror converter only handled explicit `[text](url)` links, so pasted bodies with several bare URLs landed in tickets with — at best — only the UI's first-URL autolinker doing anything. `_parse_inline` now recognises `https?://…` runs and emits one `link` mark per URL.
- Trailing sentence punctuation (`. , ; : ! ?`) and unbalanced `)` / `]` are stripped off the href so `(see https://example.com).` doesn't pull the parens or period into the link, while balanced parens (`https://en.wikipedia.org/wiki/Foo_(bar)`) are preserved.
- Round-trip stays clean: when a `link` mark's href equals its visible text and there are no other marks, `_inline_to_md` emits the bare URL instead of `[url](url)`.

## Test plan
- [x] `uv run pytest tests/test_markup.py tests/test_issue_write_path.py -x -q` (105 passed)
- [x] `uv run pytest -x -q` full suite (361 passed)
- [x] New `TestMarkdownAutolinks` covers: single URL, two URLs separated by `|`, three URLs across bullet lines (the bug's exact Gmail shape), trailing period/comma, unbalanced `)`, balanced parens, `[click](url)` still wins over autolink, `http://` scheme, round-trip preservation.
- [x] New command-level test `test_create_impl_autolinks_every_url_in_description` walks the ProseMirror payload submitted to `create_description` and asserts one `link` mark per URL — guards the CLI write path, not just the parser.