### PR TITLE
feat(ci): publish container image to ghcr.io

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+.git
+.github
+.venv
+venv
+__pycache__
+*.pyc
+*.pyo
+.pytest_cache
+.ruff_cache
+.mypy_cache
+dist
+build
+*.egg-info
+tests
+.env
+.env.*
+.DS_Store

--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -1,0 +1,54 @@
+name: Publish to GHCR
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=ref,event=branch
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -23,10 +23,10 @@ jobs:
       - uses: actions/checkout@v6.0.2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4.0.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4.1.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -34,17 +34,16 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6.0.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=ref,event=branch
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7.1.0
         with:
           context: .
           push: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,8 @@ LABEL org.opencontainers.image.licenses="MIT"
 COPY --from=builder /build/dist/*.whl /tmp/
 RUN pip install --no-cache-dir /tmp/*.whl && rm /tmp/*.whl
 
+RUN useradd --create-home --uid 1000 huly
+USER huly
+WORKDIR /home/huly
+
 ENTRYPOINT ["huly"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.12-slim AS builder
+
+WORKDIR /build
+COPY pyproject.toml README.md LICENSE ./
+COPY src ./src
+RUN pip install --no-cache-dir build && python -m build --wheel
+
+FROM python:3.12-slim
+
+LABEL org.opencontainers.image.source="https://github.com/teslakoile/huly-cli"
+LABEL org.opencontainers.image.description="CLI for Huly project management"
+LABEL org.opencontainers.image.licenses="MIT"
+
+COPY --from=builder /build/dist/*.whl /tmp/
+RUN pip install --no-cache-dir /tmp/*.whl && rm /tmp/*.whl
+
+ENTRYPOINT ["huly"]


### PR DESCRIPTION
Adds a container distribution channel for huly-cli on GitHub Container Registry, complementing the existing PyPI publish.

## What changed

- `Dockerfile` — multi-stage `python:3.12-slim` build that produces a wheel in stage one and installs it into a clean runtime stage. `ENTRYPOINT ["huly"]` so `docker run ghcr.io/teslakoile/huly-cli ...` behaves like the local CLI.
- `.dockerignore` — keeps `.git`, `tests/`, caches, and `.env` files out of the build context.
- `.github/workflows/publish-ghcr.yml` — builds and pushes on `master` (→ `:latest`) and on `v*` tags (→ `:X.Y.Z`, `:X.Y`, `:latest`) using `docker/metadata-action`. GHA cache enabled via `type=gha`.

Locally verified: image builds clean, `docker run --rm huly-cli:test --version` returns `0.1.7`, `--help` renders the full Typer command tree.

## Notes

- After the first successful publish, the package needs to be linked to this repo manually (Package settings → "Connect repository") and visibility set to public if unauthenticated `docker pull` is desired.
- The `permissions: packages: write` block on the workflow should cover GHCR pushes without changing the org-level Actions permissions, but if the first run 403s, flip Settings → Actions → General → Workflow permissions to "Read and write."