### PR TITLE
feat(ci): build container for linux/amd64 and linux/arm64

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -22,6 +22,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4.0.0
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4.0.0
 
@@ -47,6 +50,7 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha


### PR DESCRIPTION
Follow-up to #51. The published image was amd64-only, so anyone on Apple Silicon, AWS Graviton, or Raspberry Pi had to pull under emulation (verified locally — `docker pull ghcr.io/teslakoile/huly-cli:latest` on arm64 reports `no matching manifest for linux/arm64/v8` without `--platform linux/amd64`).

## What changed

- Added `docker/setup-qemu-action@v4.0.0` step before Buildx so the runner can cross-build for non-native platforms.
- `platforms: linux/amd64,linux/arm64` on the build-push step. Buildx produces a multi-arch manifest list; clients pull the matching arch automatically.

## Notes

- Build time roughly doubles (estimate ~30s → ~60s on the cached path) since arm64 builds under QEMU. Acceptable for a publish workflow that only fires on `master` and tags.
- GHA cache (`type=gha,mode=max`) is per-platform, so subsequent builds still benefit from layer reuse.